### PR TITLE
Full edit (copy edit and content edit)

### DIFF
--- a/style.md
+++ b/style.md
@@ -2003,10 +2003,23 @@ for _, tt := range tests {
 Test tables make it easier to add context to error messages, reduce duplicate
 logic, and add new test cases.
 
-
 We follow the convention that the slice of structs is referred to as `tests`
 and each test case `tt`. Further, we encourage explicating the input and output
 values for each test case with `give` and `want` prefixes.
+
+```go
+tests := []struct{
+  give     string
+  wantHost string
+  wantPort string
+}{
+  // ...
+}
+
+for _, tt := range tests {
+  // ...
+}
+```
 
 ### Functional Options
 


### PR DESCRIPTION
Overall this Style Guide looks fantastic. Prashant, Simon, and all of the others working on this have done a great job. While I made edits, they are all just suggestions that can be chosen to be included or not. Feel free to reach out to me with any additional questions.

In regards to the copy edit, I could not find anything that should not be viewed externally. Almost everything can be found externally already so I do not see a concern in that sense.

From a writing perspective, I've made some changes to the style.md file to improve consistency, readability, and the overall content flow for readers. As the audience are users of Go already, this content overall makes sense for any Go programmer outside of Uber. The changes can be viewed here, however I would like to call out a few of the larger edits. 

1. There are a few sections regarding errors, but they are spread out. I consolidated them So it flows "Error Types" -> "Error Wrapping" -> "Handle Type Assertion Failures" -> "Don't Panic" as that created the most logical flow of information. NOTE: Since there are a good amount of them, they could even be pulled out to make their own group.
2. The "Defer to Clean Up" section noted how to clean up resources such as locks so it flows best after locks are mentioned in the Mutexes sections above.
3. I've updated the TOC to reflect these changes.

A few comments for the writers to consider:

1. Under "Prefer strconv over fmt", the first sentence ends in "strconv is usually faster than fmt". Is there a time when it's not? Or do you have to test the running time to find out?
2. Under "Test Tables", the last paragraph mentions using the give and want prefixes, with all the great examples include already, it would be nice to provide one for this too.