### PR TITLE
Functional Options: Apply the interface method

### DIFF
--- a/style.md
+++ b/style.md
@@ -2099,7 +2099,7 @@ func Connect(
   }
 
   for _, o := range opts {
-    o(&options)
+    o.apply(&options)
   }
 
   // ...


### PR DESCRIPTION
This fixes a typo in the functional options code sample. When Option is
an interface, we need to `.apply` it.

Resolves #13