### PR TITLE
Zero-value mutexes: Remove leftover code sample

### DIFF
--- a/style.md
+++ b/style.md
@@ -238,13 +238,6 @@ mu.Lock()
 </td></tr>
 </tbody></table>
 
-```go
-var mu sync.Mutex
-
-mu.Lock()
-defer mu.Unlock()
-```
-
 If you use a struct by pointer, then the mutex can be a non-pointer field or,
 preferably, embedded directly into the struct.
 


### PR DESCRIPTION
We had a leftover code sample that set up a zero-value mutex and locked
and unlocked it right after the bad-good comparison.