### PR TITLE
Change index value from 0 to 1

### DIFF
--- a/style.md
+++ b/style.md
@@ -170,7 +170,7 @@ sVals := map[int]S{1: {"A"}}
 sVals[1].Read()
 
 // This will not compile:
-//  sVals[0].Write("test")
+//  sVals[1].Write("test")
 
 sPtrs := map[int]*S{1: {"A"}}
 


### PR DESCRIPTION
This was a bit confusing to digest at first. I think at a minimum, the index value should be consistent with the previous line, but it might be a little more clear to not use a `map` here.

We say at the top of the section:

```
Methods with value receivers can be called on pointers as well as values.
```

but the given example shows that only the `Read()` method works. Not the pointer receiver.

I honestly wasn't aware that being the value inside of a`map` type changed this behavior. I was expecting both to compile, because you _should_ be able to use type `S{}` with both value and pointer receivers.

I think it would be more clear to say

```go
type S struct {
  data string
}

func (s S) Read() string {
  return s.data
}

func (s *S) Write(str string) {
  s.data = str
}

sVals := S{"A"}

// You can call both Read and Write using a value
sVals.Read()
sVals.Write("test")
```