### PR TITLE
Reduce Scope: Fix FD leak

### DIFF
--- a/style.md
+++ b/style.md
@@ -1762,7 +1762,7 @@ conflicts with [Reduce Nesting](#reduce-nesting).
 <tr><td>
 
 ```go
-err := f.Close()
+err := ioutil.WriteFile(name, data, 0644)
 if err != nil {
  return err
 }
@@ -1771,7 +1771,7 @@ if err != nil {
 </td><td>
 
 ```go
-if err := f.Close(); err != nil {
+if err := ioutil.WriteFile(name, data, 0644); err != nil {
  return err
 }
 ```
@@ -1788,12 +1788,12 @@ try to reduce the scope.
 <tr><td>
 
 ```go
-if f, err := os.Open("f"); err == nil {
-  _, err = io.WriteString(f, "data")
+if data, err := ioutil.ReadFile(name); err == nil {
+  err = cfg.Decode(data)
   if err != nil {
     return err
   }
-  return f.Close()
+  return nil
 } else {
   return err
 }
@@ -1802,16 +1802,16 @@ if f, err := os.Open("f"); err == nil {
 </td><td>
 
 ```go
-f, err := os.Open("f")
+data, err := ioutil.ReadFile(name)
 if err != nil {
    return err
 }
 
-if _, err := io.WriteString(f, "data"); err != nil {
+if err := cfg.Decode(data); err != nil {
   return err
 }
 
-return f.Close()
+return nil
 ```
 
 </td></tr>

--- a/style.md
+++ b/style.md
@@ -1793,6 +1793,8 @@ if data, err := ioutil.ReadFile(name); err == nil {
   if err != nil {
     return err
   }
+
+  fmt.Println(cfg)
   return nil
 } else {
   return err
@@ -1811,6 +1813,7 @@ if err := cfg.Decode(data); err != nil {
   return err
 }
 
+fmt.Println(cfg)
 return nil
 ```
 


### PR DESCRIPTION
As pointed out in #19, the second Good example for "Reduce Scope of
Variables" leaks an open file descriptor if `io.WriteString` fails.

Further, both sets of examples are manually closing files instead of
using `defer` as pointed out elsewhere in the guide.

As these examples just need a pair of functions, one returning just an
error, another returning a value and an error, I've switched them to
using `ioutil.ReadFile`, `ioutil.WriteFile`, and a plausible
`Config.Decode([]byte) error` method on a `cfg` variable assumed to be
in-scope.

Resolves #19