### PR TITLE
README: Add translations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-This repository holds the [Uber Go Style Guide](style.md)
+This repository holds the [Uber Go Style Guide](style.md), which documents
+patterns and conventions used in Go code at Uber.
+
+## Style Guide
+
+See [Uber Go Style Guide](style.md) for the style guide.
+
+## Translations
+
+We are aware of the following translations of this guide by the Go community.
+
+- **Chinese**: [xxjwxc/uber_go_guide_cn](https://github.com/xxjwxc/uber_go_guide_cn)
+
+If you have a translation, feel free to submit a PR adding it to the list.


### PR DESCRIPTION
This adds a translations section to the README with a link to the only
translation repository that we know of at this time.

Resolves #31 