### PR TITLE
Remove embedded mutex in exportd type

### DIFF
--- a/style.md
+++ b/style.md
@@ -363,20 +363,20 @@ state.
 
 ```go
 type Stats struct {
-  sync.Mutex
-
+  mu sync.Mutex
   counters map[string]int
 }
 
 // Snapshot returns the current stats.
 func (s *Stats) Snapshot() map[string]int {
-  s.Lock()
-  defer s.Unlock()
+  s.mu.Lock()
+  defer s.mu.Unlock()
 
   return s.counters
 }
 
-// snapshot is no longer protected by the lock!
+// snapshot is no longer protected by the mutex, so any
+// access to the snapshot is racy.
 snapshot := stats.Snapshot()
 ```
 
@@ -384,14 +384,13 @@ snapshot := stats.Snapshot()
 
 ```go
 type Stats struct {
-  sync.Mutex
-
+  mu sync.Mutex
   counters map[string]int
 }
 
 func (s *Stats) Snapshot() map[string]int {
-  s.Lock()
-  defer s.Unlock()
+  s.mu.Lock()
+  defer s.mu.Unlock()
 
   result := make(map[string]int, len(s.counters))
   for k, v := range s.counters {


### PR DESCRIPTION
Related to #23.

Also clarify that any access to the snapshot would be racy to make it clear there's no safe
way to access the snapshot.

Supercedes #21.