### PR TITLE
Guideline: Use "time" to handle time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2020-01-23
+
+- Recommend using the `time` package when dealing with time.
+
 # 2019-12-17
 
 - Functional Options: Recommend struct implementations of `Option` interface

--- a/style.md
+++ b/style.md
@@ -565,6 +565,8 @@ helps deal with these incorrect assumptions in a safer, more accurate manner.
 
   [`"time"`]: https://golang.org/pkg/time/
 
+#### Use `time.Time` for instants of time
+
 Use [`time.Time`] when dealing with instants of time, and the methods on
 `time.Time` when comparing, adding, or subtracting time.
 
@@ -591,6 +593,8 @@ func isActive(now, start, stop time.Time) bool {
 
 </td></tr>
 </tbody></table>
+
+#### Use `time.Duration` for periods of time
 
 Use [`time.Duration`] when dealing with periods of time.
 
@@ -641,6 +645,8 @@ use [`Time.Add`].
 newDay := t.AddDate(0 /* years */, 0, /* months */, 1 /* days */)
 maybeNewDay := t.Add(24 * time.Hour)
 ```
+
+#### Use `time.Time` and `time.Duration` with external systems
 
 Use `time.Duration` and `time.Time` in interactions with external systems when
 possible. For example:

--- a/style.md
+++ b/style.md
@@ -652,15 +652,22 @@ maybeNewDay := t.Add(24 * time.Hour)
 Use `time.Duration` and `time.Time` in interactions with external systems when
 possible. For example:
 
-- Command-line flags: [`flag`] supports `time.Duration`
-- JSON: [`encoding/json`] supports `time.Time`
-- SQL: [`database/sql`] supports `time.Time`
-- YAML: [`gopkg.in/yaml.v2`] supports `time.Time` and `time.Duration`
+- Command-line flags: [`flag`] supports `time.Duration` via
+  [`time.ParseDuration`]
+- JSON: [`encoding/json`] supports encoding `time.Time` as an [RFC 3339]
+  string via its [`UnmarshalJSON` method]
+- SQL: [`database/sql`] supports converting `DATETIME` or `TIMESTAMP` columns
+  into `time.Time` and back if the underlying driver supports it
+- YAML: [`gopkg.in/yaml.v2`] supports `time.Time` as an [RFC 3339] string, and
+  `time.Duration` via [`time.ParseDuration`].
 
-  [`encoding/json`]: https://golang.org/pkg/encoding/json/
-  [`gopkg.in/yaml.v2`]: https://godoc.org/gopkg.in/yaml.v2
-  [`database/sql`]: https://golang.org/pkg/database/sql/
   [`flag`]: https://golang.org/pkg/flag/
+  [`time.ParseDuration`]: https://golang.org/pkg/time/#ParseDuration
+  [`encoding/json`]: https://golang.org/pkg/encoding/json/
+  [RFC 3339]: https://tools.ietf.org/html/rfc3339
+  [`UnmarshalJSON` method]: https://golang.org/pkg/time/#Time.UnmarshalJSON
+  [`database/sql`]: https://golang.org/pkg/database/sql/
+  [`gopkg.in/yaml.v2`]: https://godoc.org/gopkg.in/yaml.v2
 
 When it is not possible to use `time.Duration` in these interactions, use
 `int` or `float64` and include the unit in the name of the field.
@@ -696,7 +703,6 @@ When it is not possible to use `time.Time` in these interactions, unless an
 alternative is agreed upon, use `string` and format timestamps as defined in
 [RFC 3339]. This format is used by default by [`Time.UnmarshalText`].
 
-  [RFC 3339]: https://tools.ietf.org/html/rfc3339
   [`Time.UnmarshalText`]: https://golang.org/pkg/time/#Time.UnmarshalText
 
 Although this tends to not be a problem in practice, keep in mind that the

--- a/style.md
+++ b/style.md
@@ -683,7 +683,7 @@ is included in the name of the field.
 ```go
 // {"interval": 2}
 type Config struct {
-  Interval int
+  Interval int `json:"interval"`
 }
 ```
 
@@ -692,7 +692,7 @@ type Config struct {
 ```go
 // {"intervalMillis": 2000}
 type Config struct {
-  IntervalMillis int
+  IntervalMillis int `json:"intervalMillis"`
 }
 ```
 

--- a/style.md
+++ b/style.md
@@ -642,6 +642,15 @@ newDay := t.AddDate(0 /* years */, 0, /* months */, 1 /* days */)
 maybeNewDay := t.Add(24 * time.Hour)
 ```
 
+Although this tends to not be a problem in practice, keep in mind that the
+`"time"` package does not support parsing timestamps with leap seconds
+([8728]), nor does it account for leap seconds in calculations ([15190]). If
+you compare two instants of time, the difference will not include the leap
+seconds that may have occurred between those two instants.
+
+  [8728]: https://github.com/golang/go/issues/8728
+  [15190]: https://github.com/golang/go/issues/15190
+
 <!-- TODO: section on String methods for enums -->
 
 ### Error Types

--- a/style.md
+++ b/style.md
@@ -565,6 +565,33 @@ helps deal with these incorrect assumptions in a safer, more accurate manner.
 
   [`"time"`]: https://golang.org/pkg/time/
 
+Use [`time.Time`] when dealing with instants of time, and the methods on
+`time.Time` when comparing, adding, or subtracting time.
+
+  [`time.Time`]: https://golang.org/pkg/time/#Time
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+func isActive(now, start, stop int) bool {
+  return start <= now && now < stop
+}
+```
+
+</td><td>
+
+```go
+func isActive(now, start, stop time.Time) bool {
+  return (start.Before(now) || start.Equal(now)) && now.Before(stop)
+}
+```
+
+</td></tr>
+</tbody></table>
+
 Use [`time.Duration`] when dealing with periods of time.
 
   [`time.Duration`]: https://golang.org/pkg/time/#Duration
@@ -596,33 +623,6 @@ func poll(delay time.Duration) {
 }
 
 poll(10*time.Second)
-```
-
-</td></tr>
-</tbody></table>
-
-Use [`time.Time`] when dealing with instants of time, and the methods on
-`time.Time` when comparing, adding, or subtracting time.
-
-  [`time.Time`]: https://golang.org/pkg/time/#Time
-
-<table>
-<thead><tr><th>Bad</th><th>Good</th></tr></thead>
-<tbody>
-<tr><td>
-
-```go
-func isActive(now, start, stop int) bool {
-  return start <= now && now < stop
-}
-```
-
-</td><td>
-
-```go
-func isActive(now, start, stop time.Time) bool {
-  return (start.Before(now) || start.Equal(now)) && now.Before(stop)
-}
 ```
 
 </td></tr>

--- a/style.md
+++ b/style.md
@@ -61,7 +61,7 @@ row before the </tbody></table> line.
   - [Defer to Clean Up](#defer-to-clean-up)
   - [Channel Size is One or None](#channel-size-is-one-or-none)
   - [Start Enums at One](#start-enums-at-one)
-  - [Use time](#use-time)
+  - [Use `"time"` to handle time](#use-time-to-handle-time)
   - [Error Types](#error-types)
   - [Error Wrapping](#error-wrapping)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
@@ -546,7 +546,7 @@ const (
 // LogToStdout=0, LogToFile=1, LogToRemote=2
 ```
 
-### Use time
+### Use `"time"` to handle time
 
 Time is complicated. Incorrect assumptions often made about time include the
 following.
@@ -560,10 +560,10 @@ following.
 For example, *1* means that adding 24 hours to a time instant will not always
 yield a new calendar day.
 
-Therefore, always use the [`time`] package when dealing with time because it
+Therefore, always use the [`"time"`] package when dealing with time because it
 helps deal with these incorrect assumptions in a safer, more accurate manner.
 
-  [`time`]: https://golang.org/pkg/time/
+  [`"time"`]: https://golang.org/pkg/time/
 
 Use [`time.Duration`] when dealing with periods of time.
 

--- a/style.md
+++ b/style.md
@@ -642,6 +642,56 @@ newDay := t.AddDate(0 /* years */, 0, /* months */, 1 /* days */)
 maybeNewDay := t.Add(24 * time.Hour)
 ```
 
+Use `time.Duration` and `time.Time` in interactions with external systems when
+possible. For example:
+
+- Command-line flags: [`flag`] supports `time.Duration`
+- JSON: [`encoding/json`] supports `time.Time`
+- SQL: [`database/sql`] supports `time.Time`
+- YAML: [`gopkg.in/yaml.v2`] supports `time.Time` and `time.Duration`
+
+  [`encoding/json`]: https://golang.org/pkg/encoding/json/
+  [`gopkg.in/yaml.v2`]: https://godoc.org/gopkg.in/yaml.v2
+  [`database/sql`]: https://golang.org/pkg/database/sql/
+  [`flag`]: https://golang.org/pkg/flag/
+
+When it is not possible to use `time.Duration` in these interactions, use
+`int` or `float64` and include the unit in the name of the field.
+
+For example, since `encoding/json` does not support `time.Duration`, the unit
+is included in the name of the field.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+// {"interval": 2}
+type Config struct {
+  Interval int
+}
+```
+
+</td><td>
+
+```go
+// {"intervalMillis": 2000}
+type Config struct {
+  IntervalMillis int
+}
+```
+
+</td></tr>
+</tbody></table>
+
+When it is not possible to use `time.Time` in these interactions, unless an
+alternative is agreed upon, use `string` and format timestamps as defined in
+[RFC 3339]. This format is used by default by [`Time.UnmarshalText`].
+
+  [RFC 3339]: https://tools.ietf.org/html/rfc3339
+  [`Time.UnmarshalText`]: https://golang.org/pkg/time/#Time.UnmarshalText
+
 Although this tends to not be a problem in practice, keep in mind that the
 `"time"` package does not support parsing timestamps with leap seconds
 ([8728]), nor does it account for leap seconds in calculations ([15190]). If

--- a/style.md
+++ b/style.md
@@ -701,9 +701,11 @@ type Config struct {
 
 When it is not possible to use `time.Time` in these interactions, unless an
 alternative is agreed upon, use `string` and format timestamps as defined in
-[RFC 3339]. This format is used by default by [`Time.UnmarshalText`].
+[RFC 3339]. This format is used by default by [`Time.UnmarshalText`] and is
+available for use in `Time.Format` and `time.Parse` via [`time.RFC3339`].
 
   [`Time.UnmarshalText`]: https://golang.org/pkg/time/#Time.UnmarshalText
+  [`time.RFC3339`]: https://golang.org/pkg/time/#RFC3339
 
 Although this tends to not be a problem in practice, keep in mind that the
 `"time"` package does not support parsing timestamps with leap seconds


### PR DESCRIPTION
This adds a new section recommending use of the time package when
dealing with time. It ports over recommendations for `time.Duration` and
`time.Time` from the internal guide, explaining that time is complicated
as rationale.