### PR TITLE
Functional Options: Don't recommend closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2019-12-11
+# 2019-12-17
 
 - Functional Options: Recommend struct implementations of `Option` interface
   instead of capturing values with a closure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2019-12-11
+
+- Functional Options: Recommend individual implementations of `Option`
+  interface instead of capturing values with a closure.
+
 # 2019-11-26
 
 - Add guidance against mutating global variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2019-12-11
 
-- Functional Options: Recommend individual implementations of `Option`
-  interface instead of capturing values with a closure.
+- Functional Options: Recommend struct implementations of `Option` interface
+  instead of capturing values with a closure.
 
 # 2019-11-26
 

--- a/style.md
+++ b/style.md
@@ -2383,7 +2383,7 @@ db.Open(addr, false /* cache */, log)
 
 </td><td>
 
-Options must be provided only if needed.
+Options are provided only if needed.
 
 ```go
 db.Open(addr)

--- a/style.md
+++ b/style.md
@@ -2354,12 +2354,53 @@ db.Open(addr, false /* cache */, log)
 </td><td>
 
 ```go
+// package db
+
+type Option interface {
+  // ...
+}
+
+func WithCache(c bool) Option {
+  // ...
+}
+
+func WithLogger(log *zap.Logger) Option {
+  // ...
+}
+
+// Open creates a connection.
+func Open(
+  addr string,
+  opts ...Option,
+) (*Connection, error) {
+  // ...
+}
+
+// Options must be provided only if needed.
+
+db.Open(addr)
+db.Open(addr, db.WithLogger(log))
+db.Open(addr, db.WithCache(false))
+db.Open(
+  addr,
+  db.WithCache(false),
+  db.WithLogger(log),
+)
+```
+
+</td></tr>
+</tbody></table>
+
+Our suggested way of implementing this pattern is with an `Option` interface
+that holds an unexported method, recording options on an unexported `options`
+struct.
+
+```go
 type options struct {
   cache  bool
   logger *zap.Logger
 }
 
-// Option overrides behavior of Open.
 type Option interface {
   apply(*options)
 }
@@ -2402,21 +2443,7 @@ func Open(
 
   // ...
 }
-
-// Options must be provided only if needed.
-
-db.Open(addr)
-db.Open(addr, db.WithLogger(log))
-db.Open(addr, db.WithCache(false))
-db.Open(
-  addr,
-  db.WithCache(false),
-  db.WithLogger(log),
-)
 ```
-
-</td></tr>
-</tbody></table>
 
 Note that there's a method of implementing this pattern with closures but we
 believe that the pattern above provides more flexibility for authors and is

--- a/style.md
+++ b/style.md
@@ -2455,7 +2455,11 @@ func Open(
 
 Note that there's a method of implementing this pattern with closures but we
 believe that the pattern above provides more flexibility for authors and is
-easier to debug for users.
+easier to debug and test for users. In particular, it allows options to be
+compared against each other in tests and mocks, versus closures where this is
+impossible. Further, it lets options implement other interfaces, including
+`fmt.Stringer` which allows for user-readable string representations of the
+options.
 
 See also,
 

--- a/style.md
+++ b/style.md
@@ -2340,15 +2340,6 @@ func Open(
 ) (*Connection, error) {
   // ...
 }
-
-// The cache and logger parameters must always
-// be provided, even if the user wants to use
-// the default.
-
-db.Open(addr, db.DefaultCache, zap.NewNop())
-db.Open(addr, db.DefaultCache, log)
-db.Open(addr, false /* cache */, zap.NewNop())
-db.Open(addr, false /* cache */, log)
 ```
 
 </td><td>
@@ -2375,9 +2366,26 @@ func Open(
 ) (*Connection, error) {
   // ...
 }
+```
 
-// Options must be provided only if needed.
+</td></tr>
+<tr><td>
 
+The cache and logger parameters must always be provided, even if the user
+wants to use the default.
+
+```go
+db.Open(addr, db.DefaultCache, zap.NewNop())
+db.Open(addr, db.DefaultCache, log)
+db.Open(addr, false /* cache */, zap.NewNop())
+db.Open(addr, false /* cache */, log)
+```
+
+</td><td>
+
+Options must be provided only if needed.
+
+```go
 db.Open(addr)
 db.Open(addr, db.WithLogger(log))
 db.Open(addr, db.WithCache(false))


### PR DESCRIPTION
Per #74, this changes the recommendation for functional options to
suggest manual interface implementations instead of closures.

To make the example more demonstrative, I had to add a new option which
hurt the overall readability of the side-by-side comparison. This lead
to a minor reorganization: side-by-side includes user-facing API and
usage only, and implementation is demonstrated separately in its own
paragraph.

Resolves #74