### PR TITLE
Fix missing open function parameter

### DIFF
--- a/style.md
+++ b/style.md
@@ -638,7 +638,7 @@ func open(file string) error {
 }
 
 func use() {
-  if err := open(); err != nil {
+  if err := open("testfile.txt"); err != nil {
     if strings.Contains(err.Error(), "not found") {
       // handle
     } else {
@@ -664,7 +664,7 @@ func open(file string) error {
 }
 
 func use() {
-  if err := open(); err != nil {
+  if err := open("testfile.txt"); err != nil {
     if _, ok := err.(errNotFound); ok {
       // handle
     } else {


### PR DESCRIPTION
This PR will add the missing `open` function parameter in the Error section examples. If no parameter is used, the program will not run and we should see an error message similar to this: 

```
not enough arguments in call to open
```