### PR TITLE
Avoid embedding types in public structs

### DIFF
--- a/style.md
+++ b/style.md
@@ -1049,8 +1049,11 @@ Avoid embedding types in public structs.
 These obscure documentation and leak a detail about your implementation that
 may need to change.
 
-Assuming you have implemented a variety of `List` type using a shared
-`AbstractList`.
+Assuming you have implemented a variety of `List` types using a shared
+`AbstractList`, avoid embedding the AbstractList in your concrete list
+implementations.
+Instead, hand-write only the methods your lists will delegate to the abstract
+list.
 
 ```go
 package abstractlist
@@ -1067,8 +1070,6 @@ func (l *List) Remove(e Entity) {
     // ...
 }
 ```
-
-Avoid embedding the AbstractList in your concrete list implementations.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -1123,14 +1124,10 @@ It is a convenience that implies monotonous delegate methods.
 That the embed is part of the public interface leaks a detail about the type's
 implementation in a way that makes the type inflexible to change.
 
-For example, using an embedded type for an abstract implementation can harm
-your ability to evolve the concrete type.
-Consider a list type that "inherits" much of its interface from an underlying
-abstract list.
+Parts of the abstract list implementation are intentended to surface on the
+concrete lists, but other methods may be for the lists' indirect use, and
+others just for testing.
 
-The abstract list provides implementations for `Add` and `Remove`, as well as
-possibly a number of other methods useful for testing its particular
-implementation but immaterial to the `List`.
 Every future version of `List` is obliged indefinitely to embed `AbstractList`,
 eliminating the possibility of replacing the implementation with an alternative
 in a future version.

--- a/style.md
+++ b/style.md
@@ -1049,8 +1049,8 @@ Avoid embedding types in public structs.
 These obscure documentation and leak a detail about your implementation that
 may need to change.
 
-Assuming you have implemented a variety of `List` types using a shared
-`AbstractList`, avoid embedding the AbstractList in your concrete list
+Assuming you have implemented a variety of list types using a shared
+`AbstractList`, avoid embedding the `AbstractList` in your concrete list
 implementations.
 Instead, hand-write only the methods your lists will delegate to the abstract
 list.

--- a/style.md
+++ b/style.md
@@ -1088,6 +1088,8 @@ type ConceteList struct {
 </td><td>
 
 ```go
+package concretelist
+
 // ConceteList is a list of entities.
 type ConceteList struct {
     list *abstractlist.AbstractList
@@ -1165,6 +1167,8 @@ type ConceteList struct {
 </td><td>
 
 ```go
+package concretelist
+
 // ConceteList is a list of entities.
 type ConceteList struct {
     list *abstractlist.AbstractList

--- a/style.md
+++ b/style.md
@@ -1068,7 +1068,7 @@ Consider a list type that "inherits" much of its interface from an underlying
 abstract list.
 
 <table>
-<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<thead><tr><th>Bad</th></tr></thead>
 <tbody>
 <tr><td>
 
@@ -1079,7 +1079,23 @@ type List struct {
 }
 ```
 
-*also*
+</td></tr>
+</tbody></table>
+
+The abstract list provides implementations for `Add` and `Remove`, as well as
+possibly a number of other methods useful for testing its particular
+implementation but immaterial to the `List`.
+Every future version of `List` is obliged indefinitely to embed `AbstractList`,
+eliminating the possibility of replacing the implementation with an alternative
+in a future version.
+
+Embedding an AbstractList interface would offer the developer more flexibility
+to change in the future.
+
+<table>
+<thead><tr><th>Bad</th></tr></thead>
+<tbody>
+<tr><td>
 
 ```go
 // AbstractList is a generalized implementation
@@ -1095,7 +1111,20 @@ type List struct {
 }
 ```
 
-</td><td>
+</td></tr>
+</tbody></table>
+
+While this limits the scope of the interface to those that the List wishes to
+proxy, it would be tempting as well for the interface to capture methods that
+only the `List` will use internally, entraining those in the public API.
+The embedded interface also leaks the implementation detail that the list uses
+an abstract list at all, which is of no concern to the end user and could
+otherwise change in a future version.
+
+<table>
+<thead><tr><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
 
 ```go
 // List is a list of entities.
@@ -1114,25 +1143,8 @@ func (l *List) Remove(e Entity) {
 }
 ```
 
+</td></tr>
 </tbody></table>
-
-The abstract list provides implementations for `Add` and `Remove`, as well as
-possibly a number of other methods useful for testing its particular
-implementation but immaterial to the `List`.
-Every future version of `List` is obliged indefinitely to embed `AbstractList`,
-eliminating the possibility of replacing the implementation with an alternative
-in a future version.
-
-Embedding an AbstractList interface would offer the developer more flexibility
-to change in the future.
-
-While this limits the scope of the interface to those that the List wishes to
-proxy, it would be tempting as well for the interface to capture methods that
-only the `List` will use internally, entraining those in the public API.
-The embedded interface also leaks the implementation detail that the list uses
-an abstract list at all, which is of no concern to the end user and could
-otherwise change in a future version.
-
 
 Although writing these delegate methods is tedious, it leaves more
 opportunities for change open and also eliminates indirection for discovering

--- a/style.md
+++ b/style.md
@@ -1059,12 +1059,12 @@ type AbstractList struct {}
 
 // Add adds an entity to the list.
 func (l *AbstractList) Add(e Entity) {
-    // ...
+  // ...
 }
 
 // Remove removes an entity from the list.
 func (l *AbstractList) Remove(e Entity) {
-    // ...
+  // ...
 }
 ```
 
@@ -1076,7 +1076,7 @@ func (l *AbstractList) Remove(e Entity) {
 ```go
 // ConcreteList is a list of entities.
 type ConcreteList struct {
-    *AbstractList
+  *AbstractList
 }
 ```
 
@@ -1085,17 +1085,17 @@ type ConcreteList struct {
 ```go
 // ConcreteList is a list of entities.
 type ConcreteList struct {
-    list *AbstractList
+  list *AbstractList
 }
 
 // Add adds an entity to the list.
 func (l *ConcreteList) Add(e Entity) {
-    return l.list.Add(e)
+  return l.list.Add(e)
 }
 
 // Remove removes an entity from the list.
 func (l *ConcreteList) Remove(e Entity) {
-    return l.list.Remove(e)
+  return l.list.Remove(e)
 }
 ```
 
@@ -1130,13 +1130,13 @@ leak the detail that the concrete lists use an abstract implementation.
 // AbstractList is a generalized implementation
 // for various kinds of lists of entities.
 type AbstractList interface {
-    Add(Entity)
-    Remove(Entity)
+  Add(Entity)
+  Remove(Entity)
 }
 
 // ConcreteList is a list of entities.
 type ConcreteList struct {
-    AbstractList
+  AbstractList
 }
 ```
 
@@ -1145,17 +1145,17 @@ type ConcreteList struct {
 ```go
 // ConcreteList is a list of entities.
 type ConcreteList struct {
-    list *AbstractList
+  list *AbstractList
 }
 
 // Add adds an entity to the list.
 func (l *ConcreteList) Add(e Entity) {
-    return l.list.Add(e)
+  return l.list.Add(e)
 }
 
 // Remove removes an entity from the list.
 func (l *ConcreteList) Remove(e Entity) {
-    return l.list.Remove(e)
+  return l.list.Remove(e)
 }
 ```
 

--- a/style.md
+++ b/style.md
@@ -1061,12 +1061,12 @@ package abstractlist
 type AbstractList struct {}
 
 // Add adds an entity to the list.
-func (l *List) Add(e Entity) {
+func (l *AbstractList) Add(e Entity) {
     // ...
 }
 
 // Remove removes an entity from the list.
-func (l *List) Remove(e Entity) {
+func (l *AbstractList) Remove(e Entity) {
     // ...
 }
 ```
@@ -1077,10 +1077,10 @@ func (l *List) Remove(e Entity) {
 <tr><td>
 
 ```go
-package list
+package concretelist
 
-// List is a list of entities.
-type List struct {
+// ConceteList is a list of entities.
+type ConceteList struct {
     *abstractlist.AbstractList
 }
 ```
@@ -1088,18 +1088,18 @@ type List struct {
 </td><td>
 
 ```go
-// List is a list of entities.
-type List struct {
+// ConceteList is a list of entities.
+type ConceteList struct {
     list *abstractlist.AbstractList
 }
 
 // Add adds an entity to the list.
-func (l *List) Add(e Entity) {
+func (l *ConceteList) Add(e Entity) {
     return l.list.Add(e)
 }
 
 // Remove removes an entity from the list.
-func (l *List) Remove(e Entity) {
+func (l *ConceteList) Remove(e Entity) {
     return l.list.Remove(e)
 }
 ```
@@ -1128,7 +1128,7 @@ Parts of the abstract list implementation are intentended to surface on the
 concrete lists, but other methods may be for the lists' indirect use, and
 others just for testing.
 
-Every future version of `List` is obliged indefinitely to embed `AbstractList`,
+Every future version of `ConceteList` is obliged indefinitely to embed `AbstractList`,
 eliminating the possibility of replacing the implementation with an alternative
 in a future version.
 
@@ -1136,7 +1136,7 @@ Embedding an AbstractList *interface*, instead of the struct directly, would
 offer the developer more flexibility to change in the future.
 While this limits the scope of the interface to those that the List wishes to
 proxy, it would be tempting as well for the interface to capture methods that
-only the `List` will use internally, entraining those in the public API.
+only the `ConceteList` will use internally, entraining those in the public API.
 The embedded interface also leaks the implementation detail that the list uses
 an abstract list at all, which is of no concern to the end user and could
 otherwise change in a future version.
@@ -1147,6 +1147,8 @@ otherwise change in a future version.
 <tr><td>
 
 ```go
+package concretelist
+
 // AbstractList is a generalized implementation
 // for various kinds of lists of entities.
 type AbstractList interface {
@@ -1154,8 +1156,8 @@ type AbstractList interface {
     Remove(Entity)
 }
 
-// List is a list of entities.
-type List struct {
+// ConceteList is a list of entities.
+type ConceteList struct {
     AbstractList
 }
 ```
@@ -1163,18 +1165,18 @@ type List struct {
 </td><td>
 
 ```go
-// List is a list of entities.
-type List struct {
+// ConceteList is a list of entities.
+type ConceteList struct {
     list *abstractlist.AbstractList
 }
 
 // Add adds an entity to the list.
-func (l *List) Add(e Entity) {
+func (l *ConceteList) Add(e Entity) {
     return l.list.Add(e)
 }
 
 // Remove removes an entity from the list.
-func (l *List) Remove(e Entity) {
+func (l *ConceteList) Remove(e Entity) {
     return l.list.Remove(e)
 }
 ```

--- a/style.md
+++ b/style.md
@@ -1051,8 +1051,8 @@ documentation.
 Assuming you have implemented a variety of list types using a shared
 `AbstractList`, avoid embedding the `AbstractList` in your concrete list
 implementations.
-Instead, hand-write only the methods to your concrete list that they will
-delegate to the abstract list.
+Instead, hand-write only the methods to your concrete list that will delegate
+to the abstract list.
 
 ```go
 type AbstractList struct {}

--- a/style.md
+++ b/style.md
@@ -1056,8 +1056,6 @@ Instead, hand-write only the methods your lists will delegate to the abstract
 list.
 
 ```go
-package abstractlist
-
 type AbstractList struct {}
 
 // Add adds an entity to the list.
@@ -1077,8 +1075,6 @@ func (l *AbstractList) Remove(e Entity) {
 <tr><td>
 
 ```go
-package concretelist
-
 // ConceteList is a list of entities.
 type ConceteList struct {
     *abstractlist.AbstractList
@@ -1088,8 +1084,6 @@ type ConceteList struct {
 </td><td>
 
 ```go
-package concretelist
-
 // ConceteList is a list of entities.
 type ConceteList struct {
     list *abstractlist.AbstractList
@@ -1140,8 +1134,6 @@ otherwise change in a future version.
 <tr><td>
 
 ```go
-package concretelist
-
 // AbstractList is a generalized implementation
 // for various kinds of lists of entities.
 type AbstractList interface {
@@ -1158,11 +1150,9 @@ type ConceteList struct {
 </td><td>
 
 ```go
-package concretelist
-
 // ConceteList is a list of entities.
 type ConceteList struct {
-    list *abstractlist.AbstractList
+    list *AbstractList
 }
 
 // Add adds an entity to the list.

--- a/style.md
+++ b/style.md
@@ -1045,8 +1045,8 @@ func TestSigner(t *testing.T) {
 
 ### Avoid Embedding Types in Public Structs
 
-These leak implementation details, inhibit type evolution, and obscure
-documentation.
+These embedded types leak implementation details, inhibit type evolution, and
+obscure documentation.
 
 Assuming you have implemented a variety of list types using a shared
 `AbstractList`, avoid embedding the `AbstractList` in your concrete list
@@ -1162,9 +1162,19 @@ func (l *ConcreteList) Remove(e Entity) {
 </td></tr>
 </tbody></table>
 
-Although writing these delegate methods is tedious, it hides an implementation
-detail, leaves more opportunities for change, and also eliminates indirection
-for discovering the full List interface in documentation.
+Either with an embedded struct or an embedded interface, the embedded type
+places limits on the evolution of the type.
+
+- Adding methods to an embedded interface is a breaking change.
+- Removing methods from an embedded struct is a breaking change.
+- Removing the embedded type is a breaking change.
+- Replacing the embedded type, even with an alternative that satisfies the same
+  interface, is a breaking change.
+
+Although writing these delegate methods is tedious, the additional effort hides
+an implementation detail, leaves more opportunities for change, and also
+eliminates indirection for discovering the full List interface in
+documentation.
 
 ## Performance
 

--- a/style.md
+++ b/style.md
@@ -1123,12 +1123,6 @@ public interface.
 
 An embedded type is rarely necessary.
 It is a convenience that implies monotonous delegate methods.
-That the embed is part of the public interface leaks a detail about the type's
-implementation in a way that makes the type inflexible to change.
-
-Parts of the abstract list implementation are intentended to surface on the
-concrete lists, but other methods may be for the lists' indirect use, and
-others just for testing.
 
 Every future version of `ConceteList` is obliged indefinitely to embed `AbstractList`,
 eliminating the possibility of replacing the implementation with an alternative
@@ -1136,9 +1130,6 @@ in a future version.
 
 Embedding an AbstractList *interface*, instead of the struct directly, would
 offer the developer more flexibility to change in the future.
-While this limits the scope of the interface to those that the List wishes to
-proxy, it would be tempting as well for the interface to capture methods that
-only the `ConceteList` will use internally, entraining those in the public API.
 The embedded interface also leaks the implementation detail that the list uses
 an abstract list at all, which is of no concern to the end user and could
 otherwise change in a future version.


### PR DESCRIPTION
This change introduces a section about avoiding the use of type embedding because it limits the evolution of the container type.