### PR TITLE
Guidelines: Verify Interface Compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2020-02-16
+
+- Add guidance on verifying interface compliance with compile-time checks.
+
 # 2020-01-30
 
 - Recommend using the `time` package when dealing with time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2020-02-16
+# 2020-02-24
 
 - Add guidance on verifying interface compliance with compile-time checks.
 

--- a/style.md
+++ b/style.md
@@ -205,11 +205,17 @@ type. This is `nil` for pointer types (like `*Handler`), slices, and maps, and
 an empty struct for struct types.
 
 ```go
-type Age int
+type LogHandler struct {
+  h   http.Handler
+  log *zap.Logger
+}
 
-var _ fmt.Stringer = Age(0)
+var _ http.Handler = LogHandler{}
 
-func (a Age) String() string {
+func (h LogHandler) ServeHTTP(
+  w http.ResponseWriter,
+  r *http.Request,
+) {
   // ...
 }
 ```

--- a/style.md
+++ b/style.md
@@ -154,8 +154,13 @@ pointer.
 
 ### Verify Interface Compliance
 
-For types that are known or required to implement specific interfaces, add
-checks to verify interface compliance at compile time.
+Verify interface compliance at compile time where appropriate. This includes:
+
+- Exported types that are required to implement specific interfaces as part of
+  their API contract
+- Exported or unexported types that are part of a collection of types
+  implementing the same interface
+- Other cases where violating an interface would break users
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -163,7 +163,9 @@ checks to verify interface compliance at compile time.
 <tr><td>
 
 ```go
-type Handler struct{ /* ... */ }
+type Handler struct {
+  // ...
+}
 
 
 
@@ -178,7 +180,9 @@ func (h *Handler) ServeHTTP(
 </td><td>
 
 ```go
-type Handler struct{ /* ... */ }
+type Handler struct {
+  // ...
+}
 
 var _ http.Handler = (*Handler)(nil)
 

--- a/style.md
+++ b/style.md
@@ -200,10 +200,9 @@ func (h *Handler) ServeHTTP(
 The statement `var _ http.Handler = (*Handler)(nil)` will fail to compile if
 `*Handler` ever stops matching the `http.Handler` interface.
 
-Note that the interface was implemented on the pointer type `*Handler` above,
-which meant use of `(*Handler)(nil)` on the right side of `=`. If the
-interface was implemented on the value type, the right side would use the zero
-value of that type.
+The right hand side of the assignment should be the zero value of the asserted
+type. This is `nil` for pointer types (like `*Handler`), slices, and maps, and
+an empty struct for struct types.
 
 ```go
 type Age int


### PR DESCRIPTION
This adds advice on verifying interface compliance with
`var _ Interface = (*Foo)(nil)`.

As part of this guideline, we have to cover that if the receiver is on
the value type, the right side should be the zero value. Because of
that, the guideline is placed right before the section where we talk
about receiver types for interfaces.

Resovles #25

---

[Preview](https://github.com/uber-go/guide/blob/abg/interface-compliance/style.md#verify-interface-compliance)