### PR TITLE
Fix missing type in example for naked parameters

### DIFF
--- a/style.md
+++ b/style.md
@@ -2395,7 +2395,7 @@ const (
 type Status int
 
 const (
-  StatusReady = iota + 1
+  StatusReady Status = iota + 1
   StatusDone
   // Maybe we will have a StatusInProgress in the future.
 )


### PR DESCRIPTION
To fix #88 , add type to enum group.