### PR TITLE
Add reminder that nil slices are not always the same as empty slices

### DIFF
--- a/style.md
+++ b/style.md
@@ -2284,6 +2284,10 @@ func f(list []int) {
   </td></tr>
   </tbody></table>
 
+Remember that, while it is a valid slice, a nil slice is not equivalent to an
+allocated slice of length 0 - one is nil and the other is not - and the two may
+be treated differently in different situations (such as serialization).
+
 ### Reduce Scope of Variables
 
 Where possible, reduce scope of variables. Do not reduce the scope if it


### PR DESCRIPTION
Fixes #90.