### PR TITLE
Combine capacity guidance for maps and slices

### DIFF
--- a/style.md
+++ b/style.md
@@ -1726,7 +1726,7 @@ BenchmarkGood-4  500000000   3.25 ns/op
 ### Prefer Specifying Container Capacity
 
 Specify container capacity where possible in order to allocate memory for the
-container up front.  This minimizes subsequent allocations (by copying and
+container up front. This minimizes subsequent allocations (by copying and
 resizing of the container) as elements are added.
 
 #### Specifying Map Capacity Hints
@@ -1799,8 +1799,8 @@ make([]T, length, capacity)
 Unlike maps, slice capacity is not a hint: the compiler will allocate enough
 memory for the capacity of the slice as provided to `make()`, which means that
 subsequent `append()` operations will incur zero allocations (until the length
-of the slice matches the capacity, which will require a resize to hold
-additional elements).
+of the slice matches the capacity, after which any appends will require a resize
+to hold additional elements).
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -1743,9 +1743,9 @@ map at initialization time, which reduces the need for growing
 the map and allocations as elements are added to the map.
 
 Note that, unlike slices, map capacity hints do not guarantee complete,
-preemptive allocation, but are used to approximate the number of hashmap
-buckets required. Consequently, means that map allocations may still occur when
-adding elements to the map, even up to the specified capacity.
+preemptive allocation, but are used to approximate the number of hashmap buckets
+required. Consequently, allocations may still occur when adding elements to the
+map, even up to the specified capacity.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>


### PR DESCRIPTION
Per @prashantv's [feedback](https://github.com/uber-go/guide/pull/79#pullrequestreview-380021958) on #79:

> Suggestion: Rather than having 2 separate topics with similar guidelines, what if this was one guideline with sub-headings for maps vs slices.
> 
> We can have the common reasons, then have type-specific examples + reasons in the sub-headings.

This also expands a bit more on map allocations at initialization time.