### PR TITLE
Additional guidance on struct initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2021-03-04
+# 2021-03-15
 
 - Add guidance on omitting zero-value fields during struct initialization.
 - Add guidance on `Foo{}` versus `var` form for initialization of empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2021-03-04
+
+- Add guidance on omitting zero-value fields during struct initialization.
+- Add guidance on `Foo{}` versus `var` form for initialization of empty
+  structs.
+- Add new section for Initializing Structs, moving relevant guidances into
+  subsections of it.
+
 # 2020-06-10
 
 - Add guidance on avoiding `init()`.

--- a/style.md
+++ b/style.md
@@ -98,6 +98,7 @@ row before the </tbody></table> line.
   - [Use Raw String Literals to Avoid Escaping](#use-raw-string-literals-to-avoid-escaping)
   - [Initializing Structs](#initializing-structs)
       - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
+      - [Omit Zero Value Fields in Structs](#omit-zero-value-fields-in-structs)
       - [Initializing Struct References](#initializing-struct-references)
   - [Initializing Maps](#initializing-maps)
   - [Format Strings outside Printf](#format-strings-outside-printf)
@@ -2834,6 +2835,54 @@ tests := []struct{
 }{
   {Add, "add"},
   {Subtract, "subtract"},
+}
+```
+
+#### Omit Zero Value Fields in Structs
+
+When initializing structs with field names, omit fields that have zero values.
+These values will be set by Go automatically.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+user := User{
+  FirstName: "John",
+  LastName: "Doe",
+  MiddleName: "",
+  Admin: false,
+}
+```
+
+</td><td>
+
+```go
+user := User{
+  FirstName: "John",
+  LastName: "Doe",
+}
+```
+
+</td></tr>
+</tbody></table>
+
+This helps reduce noise for readers by omitting values that are default in
+that context. Only meaningful values are specified.
+
+Exception: Even with a zero value, field names sometimes provide valuable
+context for readers. In particular, test cases in [Test Tables](#test-tables)
+can benefit from names of fields even when they are zero-valued.
+
+```go
+tests := []struct{
+  give string
+  want int
+}{
+  {give: "0", want: 0},
+  // ...
 }
 ```
 

--- a/style.md
+++ b/style.md
@@ -91,7 +91,8 @@ row before the </tbody></table> line.
   - [Top-level Variable Declarations](#top-level-variable-declarations)
   - [Prefix Unexported Globals with _](#prefix-unexported-globals-with-_)
   - [Embedding in Structs](#embedding-in-structs)
-  - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
+  - [Initializing Structs](#initializing-structs)
+      - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
   - [Local Variable Declarations](#local-variable-declarations)
   - [nil is a valid slice](#nil-is-a-valid-slice)
   - [Reduce Scope of Variables](#reduce-scope-of-variables)
@@ -2493,7 +2494,9 @@ type Client struct {
 </td></tr>
 </tbody></table>
 
-### Use Field Names to Initialize Structs
+### Initializing Structs
+
+#### Use Field Names to Initialize Structs
 
 You should almost always specify field names when initializing structs. This is
 now enforced by [`go vet`].

--- a/style.md
+++ b/style.md
@@ -91,13 +91,13 @@ row before the </tbody></table> line.
   - [Top-level Variable Declarations](#top-level-variable-declarations)
   - [Prefix Unexported Globals with _](#prefix-unexported-globals-with-_)
   - [Embedding in Structs](#embedding-in-structs)
-  - [Initializing Structs](#initializing-structs)
-      - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
   - [Local Variable Declarations](#local-variable-declarations)
   - [nil is a valid slice](#nil-is-a-valid-slice)
   - [Reduce Scope of Variables](#reduce-scope-of-variables)
   - [Avoid Naked Parameters](#avoid-naked-parameters)
   - [Use Raw String Literals to Avoid Escaping](#use-raw-string-literals-to-avoid-escaping)
+  - [Initializing Structs](#initializing-structs)
+      - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
   - [Initializing Struct References](#initializing-struct-references)
   - [Initializing Maps](#initializing-maps)
   - [Format Strings outside Printf](#format-strings-outside-printf)
@@ -2494,50 +2494,6 @@ type Client struct {
 </td></tr>
 </tbody></table>
 
-### Initializing Structs
-
-#### Use Field Names to Initialize Structs
-
-You should almost always specify field names when initializing structs. This is
-now enforced by [`go vet`].
-
-  [`go vet`]: https://golang.org/cmd/vet/
-
-<table>
-<thead><tr><th>Bad</th><th>Good</th></tr></thead>
-<tbody>
-<tr><td>
-
-```go
-k := User{"John", "Doe", true}
-```
-
-</td><td>
-
-```go
-k := User{
-    FirstName: "John",
-    LastName: "Doe",
-    Admin: true,
-}
-```
-
-</td></tr>
-</tbody></table>
-
-Exception: Field names *may* be omitted in test tables when there are 3 or
-fewer fields.
-
-```go
-tests := []struct{
-  op Operation
-  want string
-}{
-  {Add, "add"},
-  {Subtract, "subtract"},
-}
-```
-
 ### Local Variable Declarations
 
 Short variable declarations (`:=`) should be used if a variable is being set to
@@ -2836,6 +2792,50 @@ wantError := `unknown error:"test"`
 
 </td></tr>
 </tbody></table>
+
+### Initializing Structs
+
+#### Use Field Names to Initialize Structs
+
+You should almost always specify field names when initializing structs. This is
+now enforced by [`go vet`].
+
+  [`go vet`]: https://golang.org/cmd/vet/
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+k := User{"John", "Doe", true}
+```
+
+</td><td>
+
+```go
+k := User{
+    FirstName: "John",
+    LastName: "Doe",
+    Admin: true,
+}
+```
+
+</td></tr>
+</tbody></table>
+
+Exception: Field names *may* be omitted in test tables when there are 3 or
+fewer fields.
+
+```go
+tests := []struct{
+  op Operation
+  want string
+}{
+  {Add, "add"},
+  {Subtract, "subtract"},
+}
+```
 
 ### Initializing Struct References
 

--- a/style.md
+++ b/style.md
@@ -2841,8 +2841,9 @@ tests := []struct{
 
 #### Omit Zero Value Fields in Structs
 
-When initializing structs with field names, omit fields that have zero values.
-These values will be set by Go automatically.
+When initializing structs with field names, omit fields that have zero values
+unless they provide meaningful context. Otherwise, let Go set these to zero
+values automatically.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -2873,9 +2874,9 @@ user := User{
 This helps reduce noise for readers by omitting values that are default in
 that context. Only meaningful values are specified.
 
-Exception: Even with a zero value, field names sometimes provide valuable
-context for readers. In particular, test cases in [Test Tables](#test-tables)
-can benefit from names of fields even when they are zero-valued.
+Include zero values where field names provide meaningful context. For example,
+test cases in [Test Tables](#test-tables) can benefit from names of fields
+even when they are zero-valued.
 
 ```go
 tests := []struct{

--- a/style.md
+++ b/style.md
@@ -99,6 +99,7 @@ row before the </tbody></table> line.
   - [Initializing Structs](#initializing-structs)
       - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
       - [Omit Zero Value Fields in Structs](#omit-zero-value-fields-in-structs)
+      - [Use `var` for Zero Value Structs](#use-var-for-zero-value-structs)
       - [Initializing Struct References](#initializing-struct-references)
   - [Initializing Maps](#initializing-maps)
   - [Format Strings outside Printf](#format-strings-outside-printf)
@@ -2885,6 +2886,35 @@ tests := []struct{
   // ...
 }
 ```
+
+#### Use `var` for Zero Value Structs
+
+When all the fields of a struct are omitted in a declaration, use the `var`
+form to declare the struct.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+user := User{}
+```
+
+</td><td>
+
+```go
+var user User
+```
+
+</td></tr>
+</tbody></table>
+
+This differentiates zero valued structs from those with non-zero fields
+similar to the distinction created for [map initialization], and matches how
+we prefer to [declare empty slices][Declaring Empty Slices].
+
+  [map initialization]: #initializing-maps
 
 #### Initializing Struct References
 

--- a/style.md
+++ b/style.md
@@ -98,7 +98,7 @@ row before the </tbody></table> line.
   - [Use Raw String Literals to Avoid Escaping](#use-raw-string-literals-to-avoid-escaping)
   - [Initializing Structs](#initializing-structs)
       - [Use Field Names to Initialize Structs](#use-field-names-to-initialize-structs)
-  - [Initializing Struct References](#initializing-struct-references)
+      - [Initializing Struct References](#initializing-struct-references)
   - [Initializing Maps](#initializing-maps)
   - [Format Strings outside Printf](#format-strings-outside-printf)
   - [Naming Printf-style Functions](#naming-printf-style-functions)
@@ -2837,7 +2837,7 @@ tests := []struct{
 }
 ```
 
-### Initializing Struct References
+#### Initializing Struct References
 
 Use `&T{}` instead of `new(T)` when initializing struct references so that it
 is consistent with the struct initialization.


### PR DESCRIPTION
This adds a new Struct Initialization section, moving the old "use field
names" and "initializing struct references" guidelines under it.

In the new section, based on #109, this adds the following new sections:

- Omit zero value fields
- Use var for zero value structs

Each commit is individually reviewable.

Preview: https://github.com/uber-go/guide/blob/abg/struct-init/style.md#initializing-structs
Resolves #109
