### PR TITLE
Add guidance on exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2021-04-19
 
-- Programs should exit only in `main()`.
+- Programs should exit only in `main()`, preferably at most once.
 
 # 2021-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2021-04-19
+
+- Programs should exit only in `main()`.
+
 # 2021-03-15
 
 - Add guidance on omitting zero-value fields during struct initialization.

--- a/style.md
+++ b/style.md
@@ -72,6 +72,7 @@ row before the </tbody></table> line.
   - [Avoid Embedding Types in Public Structs](#avoid-embedding-types-in-public-structs)
   - [Avoid Using Built-In Names](#avoid-using-built-in-names)
   - [Avoid `init()`](#avoid-init)
+  - [Exit in Main](#exit-in-main)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
   - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion)
@@ -1635,6 +1636,83 @@ necessary might include:
   precomputation.
 
   [Google Cloud Functions]: https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations
+
+### Exit in Main
+
+Go programs use [`os.Exit`] or [`log.Fatal*`] to exit immediately. (Panicking
+is not a good way to exit programs, please [don't panic](#dont-panic).)
+
+  [`os.Exit`]: https://golang.org/pkg/os/#Exit
+  [`log.Fatal*`]: https://golang.org/pkg/log/#Fatal
+
+Call one of `os.Exit` or `log.Fatal*` **only in `main()`**. All other
+functions should return errors to signal failure.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+func main() {
+  body := readFile(path)
+  fmt.Println(body)
+}
+
+func readFile(path string) string {
+  f, err := os.Open(path)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  b, err := ioutil.ReadAll(f)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  return string(b)
+}
+```
+
+</td><td>
+
+```go
+func main() {
+  body, err := readFile(path)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println(body)
+}
+
+func readFile(path string) (string, error) {
+  f, err := os.Open(path)
+  if err != nil {
+    return "", err
+  }
+
+  b, err := ioutil.ReadAll(f)
+  if err != nil {
+    return "", err
+  }
+
+  return string(b), nil
+}
+```
+
+</td></tr>
+</tbody></table>
+
+Rationale: Programs with multiple functions that exit present a few issues:
+
+- Non-obvious control flow: Any function can exit the program so it becomes
+  difficult to reason about the control flow.
+- Difficult to test: A function that exits the program will also exit the test
+  calling it. This makes the function difficult to test and introduces risk of
+  skipping other tests that have not yet been run by `go test`.
+- Skipped cleanup: When a function exits the program, it skips function calls
+  enqueued with `defer` statements. This adds risk of skipping important
+  cleanup tasks.
 
 ## Performance
 


### PR DESCRIPTION
In #66, we discussed advising at most one `log.Fatal` per program. This
can be split into two pieces of guidance:

1. exit only in main
2. exit only once

Applying to both, `os.Exit` and `log.Fatal`.

This adds (1) as a guidance to the style guide, and (2) as an optional
"upgrade" for extra points.

At minimum, (1) gives us easy-to-follow control flow and testability
outside main. If readers are sold on that, (2) gives us testable
`main()` logic.

Preview: https://github.com/uber-go/guide/blob/abg/exit-once/style.md#exit-in-main
Resolves #66
