### PR TITLE
Go Common Mistakes: Title case

### DIFF
--- a/style.md
+++ b/style.md
@@ -129,7 +129,7 @@ of these are general guidelines for Go, while others extend upon external
 resources:
 
 1. [Effective Go](https://golang.org/doc/effective_go.html)
-2. [The Go common mistakes guide](https://github.com/golang/go/wiki/CommonMistakes)
+2. [Go Common Mistakes](https://github.com/golang/go/wiki/CommonMistakes)
 3. [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
 
 All code should be error-free when run through `golint` and `go vet`. We


### PR DESCRIPTION
Title case the link for Go Common Mistakes guide to match format of
other links.