### PR TITLE
errors: Update for errors.Is/As

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2021-11-16
+
+- Add guidance on use of `%w` vs `%v` with `fmt.Errorf`, and where to use
+  `errors.New` or custom error types.
+
 # 2021-11-12
 
 - Add soft line length limit of 99 characters.

--- a/style.md
+++ b/style.md
@@ -956,15 +956,15 @@ There are three main options for propagating errors if a call fails:
 
 - Return the original error if there is no additional context to add and you
   want to maintain the original error type.
-- Add context using [`"pkg/errors".Wrap`] so that the error message provides
-  more context and [`"pkg/errors".Cause`] can be used to extract the original
-  error.
-- Use [`fmt.Errorf`] if the callers do not need to detect or handle that
-  specific error case.
+- Add context using `fmt.Errorf` with a `%w` verb if you want callers to
+  be able to match against or extract the original error.
+  If you do this, note that this is now part of your public API.
+- Add context with `fmt.Errorf` with a `%v` verb if callers should not match
+  that error separately.
 
-It is recommended to add context where possible so that instead of a vague
-error such as "connection refused", you get more useful errors such as
-"call service foo: connection refused".
+We recommend adding context where possible so that
+instead of a vague error such as "connection refused",
+you get more useful errors such as "call service foo: connection refused".
 
 When adding context to returned errors, keep the context succinct by avoiding
 phrases like "failed to", which state the obvious and pile up as the error
@@ -979,7 +979,7 @@ percolates up through the stack:
 s, err := store.New()
 if err != nil {
     return fmt.Errorf(
-        "failed to create new store: %v", err)
+        "failed to create new store: %w", err)
 }
 ```
 
@@ -989,7 +989,7 @@ if err != nil {
 s, err := store.New()
 if err != nil {
     return fmt.Errorf(
-        "new store: %v", err)
+        "new store: %w", err)
 }
 ```
 

--- a/style.md
+++ b/style.md
@@ -950,8 +950,8 @@ if err := foo.Open("testfile.txt"); err != nil {
 </td></tr>
 </tbody></table>
 
-Be careful with exporting error variables or types.
-These will become part of the public API of your package.
+Note that if you export error variables or types from a package,
+they will become part of the public API of the package.
 
 #### Error Wrapping
 
@@ -1027,21 +1027,48 @@ This guidance supersedes the [Prefix Unexported Globals with _](#prefix-unexport
 
 ```go
 var (
-  errNotFound = errors.New("not found")
+  // The following two errors are exported
+  // so that users of this package can match them
+  // with errors.Is.
+
   ErrBrokenLink = errors.New("link is broken")
   ErrCouldNotOpen = errors.New("could not open")
+
+  // This error is not exported because
+  // we don't want to make it part of our public API.
+  // We may still use it inside the package
+  // with errors.Is.
+
+  errNotFound = errors.New("not found")
 )
 ```
 
 For custom error types, use the suffix `Error` instead.
 
 ```go
+// Similarly, this error is exported
+// so that users of this package can match it
+// with errors.As.
+
 type NotFoundError struct {
   File string
 }
 
 func (e NotFoundError) Error() string {
   return fmt.Sprintf("file %q not found", e.File)
+}
+
+// And this error is not exported because
+// we don't want to make it part of the public API.
+// We can still use it inside the package
+// with errors.As.
+
+type resolveError struct {
+  Path string
+}
+
+func (e resolveError) Error() string {
+  return fmt.Sprintf("resolve %q", e.Path)
 }
 ```
 

--- a/style.md
+++ b/style.md
@@ -63,8 +63,9 @@ row before the </tbody></table> line.
   - [Channel Size is One or None](#channel-size-is-one-or-none)
   - [Start Enums at One](#start-enums-at-one)
   - [Use `"time"` to handle time](#use-time-to-handle-time)
-  - [Error Types](#error-types)
-  - [Error Wrapping](#error-wrapping)
+  - [Errors](#errors)
+    - [Error Types](#error-types)
+    - [Error Wrapping](#error-wrapping)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
   - [Don't Panic](#dont-panic)
   - [Use go.uber.org/atomic](#use-gouberorgatomic)
@@ -811,8 +812,9 @@ seconds that may have occurred between those two instants.
 
 <!-- TODO: section on String methods for enums -->
 
-### Error Types
+### Errors
 
+#### Error Types
 
 There are few options for declaring errors.
 Consider the following before picking the option best suited for your use case.
@@ -950,7 +952,7 @@ func use() {
 Be careful with exporting error variables or types.
 These will become part of the public API of your package.
 
-### Error Wrapping
+#### Error Wrapping
 
 There are three main options for propagating errors if a call fails:
 

--- a/style.md
+++ b/style.md
@@ -66,7 +66,7 @@ row before the </tbody></table> line.
   - [Errors](#errors)
     - [Error Types](#error-types)
     - [Error Wrapping](#error-wrapping)
-    - [Error naming](#error-naming)
+    - [Error Naming](#error-naming)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
   - [Don't Panic](#dont-panic)
   - [Use go.uber.org/atomic](#use-gouberorgatomic)
@@ -1019,7 +1019,7 @@ See also [Don't just check errors, handle them gracefully].
   [`"pkg/errors".Cause`]: https://godoc.org/github.com/pkg/errors#Cause
   [Don't just check errors, handle them gracefully]: https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
 
-#### Error naming
+#### Error Naming
 
 For error values stored as global variables,
 use the prefix `Err` or `err` depending on whether they're exported.
@@ -2541,7 +2541,7 @@ const (
 </tbody></table>
 
 **Exception**: Unexported error values may use the prefix `err` without the underscore.
-See [Error naming](#error-naming).
+See [Error Naming](#error-naming).
 
 ### Embedding in Structs
 

--- a/style.md
+++ b/style.md
@@ -66,6 +66,7 @@ row before the </tbody></table> line.
   - [Errors](#errors)
     - [Error Types](#error-types)
     - [Error Wrapping](#error-wrapping)
+    - [Error naming](#error-naming)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
   - [Don't Panic](#dont-panic)
   - [Use go.uber.org/atomic](#use-gouberorgatomic)
@@ -1017,6 +1018,32 @@ See also [Don't just check errors, handle them gracefully].
 
   [`"pkg/errors".Cause`]: https://godoc.org/github.com/pkg/errors#Cause
   [Don't just check errors, handle them gracefully]: https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
+
+#### Error naming
+
+For error values stored as global variables,
+use the prefix `Err` or `err` depending on whether they're exported.
+This guidance supersedes the [Prefix Unexported Globals with _](#prefix-unexported-globals-with-_).
+
+```go
+var (
+  errNotFound = errors.New("not found")
+  ErrBrokenLink = errors.New("link is broken")
+  ErrCouldNotOpen = errors.New("could not open")
+)
+```
+
+For custom error types, use the suffix `Error` instead.
+
+```go
+type NotFoundError struct {
+  File string
+}
+
+func (e NotFoundError) Error() string {
+  return fmt.Sprintf("file %q not found", e.File)
+}
+```
 
 ### Handle Type Assertion Failures
 
@@ -2485,6 +2512,9 @@ const (
 
 </td></tr>
 </tbody></table>
+
+**Exception**: Unexported error values may use the prefix `err` without the underscore.
+See [Error naming](#error-naming).
 
 ### Embedding in Structs
 


### PR DESCRIPTION
This PR updates the guidance we have for errors to reflect best practices since
Go 1.13's error APIs. The high-level overview of the guidance is:

- use `errors.New` for static strings,
  exporting a `var` if it needs to be matched
- declare a custom error type if it needs to be matched
- use `fmt.Errorf` for dynamic strings if it does not need to be matched
- use `fmt.Errorf` with `%w` when wrapping if the wrapped error needs to be
  matched
- name top-level error variables `errFoo` or `ErrFoo`
- name error types `FooError`

Resolves #132, #8
Ref GO-1014

---

[Preview](https://github.com/uber-go/guide/blob/error-wrapping/style.md)