### PR TITLE
Clarify mutexes should not be embedded

### DIFF
--- a/style.md
+++ b/style.md
@@ -509,7 +509,8 @@ snapshot := stats.Snapshot()
 
 ### Defer to Clean Up
 
-Use defer to clean up resources such as files and locks.
+Use defer to clean up resources 
+files and locks.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -2561,7 +2562,7 @@ See [Error Naming](#error-naming).
 
 ### Embedding in Structs
 
-Embedded types (such as mutexes) should be at the top of the field list of a
+Embedded types should be at the top of the field list of a
 struct, and there must be an empty line separating embedded fields from regular
 fields.
 
@@ -2593,6 +2594,7 @@ type Client struct {
 Embedding should provide tangible benefit, like adding or augmenting
 functionality in a semantically-appropriate way. It should do this with zero
 adverse user-facing effects (see also: [Avoid Embedding Types in Public Structs]).
+Generally, mutexes should not be embedded.
 
   [Avoid Embedding Types in Public Structs]: #avoid-embedding-types-in-public-structs
 

--- a/style.md
+++ b/style.md
@@ -509,8 +509,7 @@ snapshot := stats.Snapshot()
 
 ### Defer to Clean Up
 
-Use defer to clean up resources 
-files and locks.
+Use defer to clean up resources files and locks.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -509,7 +509,7 @@ snapshot := stats.Snapshot()
 
 ### Defer to Clean Up
 
-Use defer to clean up resources files and locks.
+Use defer to clean up resources such as files and locks.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -2593,7 +2593,7 @@ type Client struct {
 Embedding should provide tangible benefit, like adding or augmenting
 functionality in a semantically-appropriate way. It should do this with zero
 adverse user-facing effects (see also: [Avoid Embedding Types in Public Structs]).
-Generally, mutexes should not be embedded.
+Generally, mutexes should not be embedded unless they are an integral part of the embedding type's API.
 
   [Avoid Embedding Types in Public Structs]: #avoid-embedding-types-in-public-structs
 


### PR DESCRIPTION
The instructions were contradictory:
- description say "embedded structs such as mutexes"
- later on, examples lists mutexes as something that shouldn't be embedded.

Let's clarify.