### PR TITLE
Added guidance on field tags in marshalled structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2022-03-30
 
-- Add guidance on using field tags in marshalled structs.
+- Add guidance on using field tags in marshaled structs.
 
 # 2021-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-03-30
+
+- Add guidance on using field tags in marshalled structs.
+
 # 2021-11-16
 
 - Add guidance on use of `%w` vs `%v` with `fmt.Errorf`, and where to use

--- a/style.md
+++ b/style.md
@@ -76,6 +76,7 @@ row before the </tbody></table> line.
   - [Avoid `init()`](#avoid-init)
   - [Exit in Main](#exit-in-main)
     - [Exit Once](#exit-once)
+  - [Use field tags in marshalled structs](#use-field-tags-in-marshalled-structs)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
   - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion)
@@ -1841,6 +1842,46 @@ func run() error {
 
 </td></tr>
 </tbody></table>
+
+### Use field tags in marshalled structs
+Any struct field that is marshalled into JSON, YAML or other formats, must have relevant tag.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+type T struct {
+  Number int
+  String string
+}
+bytes, err := json.Marshal(T{
+  Number: 137,
+  String: "uber",
+})
+```
+
+</td><td>
+
+```go
+type T struct {
+  Number int    `json:"number"`
+  String string `json:"string"`
+}
+bytes, err := json.Marshal(T{
+  Number: 137,
+  String: "uber",
+})
+```
+
+</td></tr>
+</tbody></table>
+
+Rationale: Structure of JSON/YAML, including field names, is a contract.
+In order to make it more explicit, always use field tags to specify the name
+of the field in marshaled data, because otherwise you may change
+the JSON/YAML format if you rename certain fields during some refactoring.
 
 ## Performance
 

--- a/style.md
+++ b/style.md
@@ -1881,10 +1881,12 @@ bytes, err := json.Marshal(Stock{
 </td></tr>
 </tbody></table>
 
-The structure of JSON, YAML, and other formats, including field names, is a
-contract. In order to make that contract more explicit, field name struct tags
-should be used to ensure that fields names are consistent and do not change
-unexpectedly when changes to the structs fields are made.
+Rationale:
+The serialized form of the structure is a contract between different systems.
+Changes to the structure of the serialized form--including field names--break
+this contract. Specifying field names inside tags makes the contract explicit,
+and it guards against accidentally breaking the contract by refactoring or
+renaming fields.
 
 ## Performance
 

--- a/style.md
+++ b/style.md
@@ -1845,7 +1845,9 @@ func run() error {
 
 ### Use field tags in marshaled structs
 
-Any struct field that is marshaled into JSON, YAML, or other formats that support tag-based field naming should be annotated with the relevant tag.
+Any struct field that is marshaled into JSON, YAML,
+or other formats that support tag-based field naming
+should be annotated with the relevant tag.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -1852,26 +1852,26 @@ Any struct field that is marshaled into JSON, YAML, or other formats that suppor
 <tr><td>
 
 ```go
-type T struct {
-  Number int
-  String string
+type Stock struct {
+  Price int
+  Name string
 }
-bytes, err := json.Marshal(T{
-  Number: 137,
-  String: "uber",
+bytes, err := json.Marshal(Stock{
+  Price: 137,
+  Name: "UBER",
 })
 ```
 
 </td><td>
 
 ```go
-type T struct {
-  Number int    `json:"number"`
-  String string `json:"string"`
+type Stock struct {
+  Price int    `json:"price"`
+  Name string `json:"name"` // now it is safer to rename this field from Name to Symbol
 }
-bytes, err := json.Marshal(T{
-  Number: 137,
-  String: "uber",
+bytes, err := json.Marshal(Stock{
+  Price: 137,
+  Name: "UBER",
 })
 ```
 

--- a/style.md
+++ b/style.md
@@ -1857,11 +1857,12 @@ should be annotated with the relevant tag.
 ```go
 type Stock struct {
   Price int
-  Name string
+  Name  string
 }
+
 bytes, err := json.Marshal(Stock{
   Price: 137,
-  Name: "UBER",
+  Name:  "UBER",
 })
 ```
 
@@ -1870,11 +1871,13 @@ bytes, err := json.Marshal(Stock{
 ```go
 type Stock struct {
   Price int    `json:"price"`
-  Name string `json:"name"` // now it is safer to rename this field from Name to Symbol
+  Name  string `json:"name"`
+  // Safe to rename Name to Symbol.
 }
+
 bytes, err := json.Marshal(Stock{
   Price: 137,
-  Name: "UBER",
+  Name:  "UBER",
 })
 ```
 

--- a/style.md
+++ b/style.md
@@ -76,7 +76,7 @@ row before the </tbody></table> line.
   - [Avoid `init()`](#avoid-init)
   - [Exit in Main](#exit-in-main)
     - [Exit Once](#exit-once)
-  - [Use field tags in marshalled structs](#use-field-tags-in-marshalled-structs)
+  - [Use field tags in marshaled structs](#use-field-tags-in-marshaled-structs)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
   - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion)
@@ -1843,7 +1843,8 @@ func run() error {
 </td></tr>
 </tbody></table>
 
-### Use field tags in marshalled structs
+### Use field tags in marshaled structs
+
 Any struct field that is marshaled into JSON, YAML, or other formats that support tag-based field naming should be annotated with the relevant tag.
 
 <table>

--- a/style.md
+++ b/style.md
@@ -1844,7 +1844,7 @@ func run() error {
 </tbody></table>
 
 ### Use field tags in marshalled structs
-Any struct field that is marshalled into JSON, YAML or other formats, must have relevant tag.
+Any struct field that is marshaled into JSON, YAML, or other formats that support tag-based field naming should be annotated with the relevant tag.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -1878,10 +1878,10 @@ bytes, err := json.Marshal(T{
 </td></tr>
 </tbody></table>
 
-Rationale: Structure of JSON/YAML, including field names, is a contract.
-In order to make it more explicit, always use field tags to specify the name
-of the field in marshaled data, because otherwise you may change
-the JSON/YAML format if you rename certain fields during some refactoring.
+The structure of JSON, YAML, and other formats, including field names, is a
+contract. In order to make that contract more explicit, field name struct tags
+should be used to ensure that fields names are consistent and do not change
+unexpectedly when changes to the structs fields are made.
 
 ## Performance
 


### PR DESCRIPTION
Updating public guide with previously discussed (internally) proposal on tagging struct fields that are being marshalled into JSON/YAML/etc