### PR TITLE
Add guidance on goroutine lifecycle management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-10-17
+
+- Add guidance on managing goroutine lifecycles.
+
 # 2022-03-30
 
 - Add guidance on using field tags in marshaled structs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2022-10-17
+# 2022-10-18
 
 - Add guidance on managing goroutine lifecycles.
 

--- a/style.md
+++ b/style.md
@@ -78,6 +78,7 @@ row before the </tbody></table> line.
     - [Exit Once](#exit-once)
   - [Use field tags in marshaled structs](#use-field-tags-in-marshaled-structs)
   - [Don't fire-and-forget goroutines](#dont-fire-and-forget-goroutines)
+    - [Wait for goroutines to exit](#wait-for-goroutines-to-exit)
     - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
@@ -1974,8 +1975,9 @@ and we can wait for it to exit with `<-done`.
 </td></tr>
 </tbody></table>
 
-Given a goroutine with a predictable lifetime,
-or a goroutine that can be stopped with a signal,
+#### Wait for goroutines to exit
+
+Given a goroutine spawned by the sytem,
 there must be a way to wait for the goroutine to exit.
 There are two popular ways to do this:
 

--- a/style.md
+++ b/style.md
@@ -1898,8 +1898,8 @@ renaming fields.
 
 ### Don't fire-and-forget goroutines
 
-Goroutines are lightweight, but they're not free.
-Do not leak goroutines in production code.
+Goroutines are lightweight, but they're not free. They cost memory.
+Leaking goroutines slowly consume more and more memory.
 In general, every goroutine:
 
 - must have a predictable time at which it will stop running; or

--- a/style.md
+++ b/style.md
@@ -78,7 +78,7 @@ row before the </tbody></table> line.
     - [Exit Once](#exit-once)
   - [Use field tags in marshaled structs](#use-field-tags-in-marshaled-structs)
   - [Don't fire-and-forget goroutines](#dont-fire-and-forget-goroutines)
-    - [No goroutines in `init()`](#no-goroutines-in-init )
+    - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
   - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion)

--- a/style.md
+++ b/style.md
@@ -2046,13 +2046,20 @@ func doWork() {
 type Worker struct{ /* ... */ }
 
 func NewWorker(...) *Worker {
-  w := &Worker{/* .. */}
+  w := &Worker{
+    stop: make(chan struct{}),
+    done: make(chan struct{}),
+    // ...
+  }
   go w.doWork()
 }
 
 func (w *Worker) doWork() {
+  defer close(w.done)
   for {
     // ...
+    case <-w.stop:
+      return
   }
 }
 
@@ -2067,7 +2074,7 @@ func (w *Worker) Shutdown() {
 </td></tr>
 <tr><td>
 
-Spawns a background goroutine unconditionally if the user exports this package.
+Spawns a background goroutine unconditionally when the user exports this package.
 The user has no control over the goroutine or a means of stopping it.
 
 </td><td>
@@ -2075,6 +2082,11 @@ The user has no control over the goroutine or a means of stopping it.
 Spawns the worker only if the user requests it.
 Provides a means of shutting down the worker so that the user can free up
 resources used by the worker.
+
+Note that you should use `WaitGroup`s if the worker manages multiple
+goroutines.
+See [Wait for goroutines to exit](#wait-for-goroutines-to-exit).
+
 
 </td></tr>
 </tbody></table>

--- a/style.md
+++ b/style.md
@@ -1966,8 +1966,9 @@ This goroutine can be stopped with `close(stop)`.
 </td></tr>
 </tbody></table>
 
-Given a means of stopping the goroutine,
-there must be a way to wait for it to stop.
+Given a goroutine with a predictable lifetime,
+or a goroutine that can be stopped with a signal,
+there must be a way to wait for the goroutine to exit.
 There are two popular ways to do this:
 
 - Use a `sync.WaitGroup`.

--- a/style.md
+++ b/style.md
@@ -1900,6 +1900,11 @@ renaming fields.
 
 Goroutines are lightweight, but they're not free. They cost memory.
 Leaking goroutines slowly consume more and more memory.
+
+Therefore, do not leak goroutines in production code.
+Use [go.uber.org/goleak](https://pkg.go.dev/go.uber.org/goleak)
+to test for goroutine leaks inside packages that may spawn goroutines.
+
 In general, every goroutine:
 
 - must have a predictable time at which it will stop running; or

--- a/style.md
+++ b/style.md
@@ -1898,8 +1898,14 @@ renaming fields.
 
 ### Don't fire-and-forget goroutines
 
-Goroutines are lightweight, but they're not free. They cost memory.
-Leaking goroutines slowly consume more and more memory.
+Goroutines are lightweight, but they're not free:
+at minimum, they cost memory for their stack and CPU to be scheduled.
+While these costs are small for typical uses of goroutines,
+they can cause significant performance issues
+when spawned in large numbers without controlled lifetimes.
+Goroutines with unmanaged lifetimes can also cause other issues
+like preventing unused objects from being garbage collected
+and holding onto resources that are otherwise no longer used.
 
 Therefore, do not leak goroutines in production code.
 Use [go.uber.org/goleak](https://pkg.go.dev/go.uber.org/goleak)

--- a/style.md
+++ b/style.md
@@ -1938,8 +1938,11 @@ go func() {
 </td><td>
 
 ```go
-stop := make(chan struct{})
+stop := make(chan struct{}) // tells the goroutine to stop
+done := make(chan struct{}) // tells us that the goroutine exited
 go func() {
+  defer close(done)
+
   ticker := time.NewTicker(delay)
   defer ticker.Stop()
   for {
@@ -1951,6 +1954,10 @@ go func() {
     }
   }
 }()
+
+// Elsewhere...
+close(stop)  // signal the goroutine to stop
+<-done       // and wait for it to exit
 ```
 
 </td></tr>
@@ -1961,7 +1968,8 @@ This will run until the application exits.
 
 </td><td>
 
-This goroutine can be stopped with `close(stop)`.
+This goroutine can be stopped with `close(stop)`,
+and we can wait for it to exit with `<-done`.
 
 </td></tr>
 </tbody></table>

--- a/style.md
+++ b/style.md
@@ -1992,7 +1992,7 @@ There are two popular ways to do this:
 
 #### No goroutines in `init()`
 
-`init()` functions should almost never spawn goroutines.
+`init()` functions should not spawn goroutines.
 See also [Avoid init()](#avoid-init).
 
 If a package has need of a background goroutine,

--- a/style.md
+++ b/style.md
@@ -1939,8 +1939,10 @@ go func() {
 </td><td>
 
 ```go
-stop := make(chan struct{}) // tells the goroutine to stop
-done := make(chan struct{}) // tells us that the goroutine exited
+var (
+  stop = make(chan struct{}) // tells the goroutine to stop
+  done = make(chan struct{}) // tells us that the goroutine exited
+)
 go func() {
   defer close(done)
 

--- a/style.md
+++ b/style.md
@@ -2010,8 +2010,8 @@ See also [Avoid init()](#avoid-init).
 If a package has need of a background goroutine,
 it must expose an object that is responsible for managing a goroutine's
 lifetime.
-The object must provide a Close or Shutdown method that signals shutdown
-to the background goroutine, and waits for it to exit.
+The object must provide a method (`Close`, `Stop`, `Shutdown`, etc)
+that signals the background goroutine to stop, and waits for it to exit.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -1976,8 +1976,8 @@ There are two popular ways to do this:
 
     ```go
     var wg sync.WaitGroup
-    wg.Add(N)
     for i := 0; i < N; i++ {
+      wg.Add(1)
       go func() {
         defer wg.Done()
         // ...


### PR DESCRIPTION
This is mostly an RFC based on some internal discussions.
In general, we prefer for goroutines to have well-managed lifecycles.
No uncontrolled background work that cannot be stopped.

This change tries to distill some of the guidance around it into a style
guide entry.
It's not super comprehensive, but it tries to cover some of the guiding
principles.

Rendered: https://github.com/uber-go/guide/blob/goroutines/style.md#dont-fire-and-forget-goroutines