### PR TITLE
Update .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 # Refer to golangci-lint's example config file for more options and information:
-# https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 
 run:
   timeout: 5m


### PR DESCRIPTION
This PR fixes the link to the example golangci config file in .golangci.yml.
Previously at https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml, now it's accessible at https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml