### PR TITLE
interface-receiver: Clarify why value receiver can be called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2023-03-03
+
+- Receivers and Interfaces: Clarify subtlety with pointer receivers and values.
+
 # 2022-10-18
 
 - Add guidance on managing goroutine lifecycles.

--- a/src/interface-receiver.md
+++ b/src/interface-receiver.md
@@ -20,17 +20,22 @@ func (s *S) Write(str string) {
   s.data = str
 }
 
+// We cannot get pointers to value stored in maps.
 sVals := map[int]S{1: {"A"}}
 
-// You can only call Read using a value
+// We can call Read on values stored in the map because Read
+// has a value receiver.
 sVals[1].Read()
 
-// This will not compile:
+// We cannot call Write on values stored in the map because Write
+// has a pointer receiver, and it's not possible to get a pointer
+// to a value stored in a map.
+//
 //  sVals[1].Write("test")
 
 sPtrs := map[int]*S{1: {"A"}}
 
-// You can call both Read and Write using a pointer
+// You can call both Read and Write if the map stores pointers.
 sPtrs[1].Read()
 sPtrs[1].Write("test")
 ```

--- a/src/interface-receiver.md
+++ b/src/interface-receiver.md
@@ -20,11 +20,13 @@ func (s *S) Write(str string) {
   s.data = str
 }
 
-// We cannot get pointers to value stored in maps.
+// We cannot get pointers to values stored in maps, because they are not
+// addressable values.
 sVals := map[int]S{1: {"A"}}
 
 // We can call Read on values stored in the map because Read
-// has a value receiver.
+// has a value receiver, which does not require the value to
+// be addressable.
 sVals[1].Read()
 
 // We cannot call Write on values stored in the map because Write
@@ -35,7 +37,8 @@ sVals[1].Read()
 
 sPtrs := map[int]*S{1: {"A"}}
 
-// You can call both Read and Write if the map stores pointers.
+// You can call both Read and Write if the map stores pointers,
+// because pointers are intrinsically addressable.
 sPtrs[1].Read()
 sPtrs[1].Write("test")
 ```

--- a/style.md
+++ b/style.md
@@ -216,17 +216,22 @@ func (s *S) Write(str string) {
   s.data = str
 }
 
+// We cannot get pointers to value stored in maps.
 sVals := map[int]S{1: {"A"}}
 
-// You can only call Read using a value
+// We can call Read on values stored in the map because Read
+// has a value receiver.
 sVals[1].Read()
 
-// This will not compile:
+// We cannot call Write on values stored in the map because Write
+// has a pointer receiver, and it's not possible to get a pointer
+// to a value stored in a map.
+//
 //  sVals[1].Write("test")
 
 sPtrs := map[int]*S{1: {"A"}}
 
-// You can call both Read and Write using a pointer
+// You can call both Read and Write if the map stores pointers.
 sPtrs[1].Read()
 sPtrs[1].Write("test")
 ```

--- a/style.md
+++ b/style.md
@@ -216,11 +216,13 @@ func (s *S) Write(str string) {
   s.data = str
 }
 
-// We cannot get pointers to value stored in maps.
+// We cannot get pointers to values stored in maps, because they are not
+// addressable values.
 sVals := map[int]S{1: {"A"}}
 
 // We can call Read on values stored in the map because Read
-// has a value receiver.
+// has a value receiver, which does not require the value to
+// be addressable.
 sVals[1].Read()
 
 // We cannot call Write on values stored in the map because Write
@@ -231,7 +233,8 @@ sVals[1].Read()
 
 sPtrs := map[int]*S{1: {"A"}}
 
-// You can call both Read and Write if the map stores pointers.
+// You can call both Read and Write if the map stores pointers,
+// because pointers are intrinsically addressable.
 sPtrs[1].Read()
 sPtrs[1].Write("test")
 ```


### PR DESCRIPTION
The guidance in this section was a bit confusing
because it didn't quite explain why we could only call Read, not Write,
on the values stored in the map.

Resolves #163
