### PR TITLE
make: Fix lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 # Setting GOBIN makes 'go install' put the binary in the bin/ directory.
 export GOBIN ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/bin
 


### PR DESCRIPTION
The lint target currently fails silently in CI
because of the use of `[[`.

    /bin/sh: 2: [[: not found

This is because `[[` is a built-in in bash, not in sh.
sh only has `[`.

Fix this by setting the shell to bash in make.
