### PR TITLE
ci/stitchmd: Support updating PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ '*' ]
 
 jobs:
@@ -19,6 +19,14 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
+      with:
+        # Check out the pull request repository and branch.
+        # If the PR is made from a fork, this will check out the fork.
+        # This is necessary for git-auto-commit-action to update PRs made by forks.
+        # See 
+        # https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.head_ref }}
 
     - name: Check or update style.md
       uses: abhinav/stitchmd-action@v1


### PR DESCRIPTION
The operation failed in #174 because the PR was made from a fork. Looking at the [documentation for git-auto-commit-acton](https://github.com/stefanzweifel/git-auto-commit-action), it's possible to support this for forks as well if we use the `pull_request_target` event (which runs in the context of the base branch), and check out the PR repository (which may be a fork). See also https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories.