### PR TITLE
ci/stitchmd: Fix write mode for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # without a local checkout.
         #
         # Otherwise, run in 'check' mode to fail CI if style.md is out-of-date.
-        mode: ${{ github.event_name == 'pull_request' && 'write' || 'check' }}
+        mode: ${{ github.event_name == 'pull_request_target' && 'write' || 'check' }}
         summary: src/SUMMARY.md
         preface: src/preface.txt
         output: style.md


### PR DESCRIPTION
#181 tried to fix support for PRs from forks
by changing the event to pull_request_target.
However, it did not update the check we do on github.event_name later
to decide whether we're in check mode or write.

This updates the job to fix the event name match.