### PR TITLE
ci/stitchmd: Run git-auto-commit-action on pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         output: style.md
 
     - uses: stefanzweifel/git-auto-commit-action@v4
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request_target' }}
       with:
         file_pattern: style.md
         commit_message: 'Auto-update style.md'


### PR DESCRIPTION
Auto-commit to PRs only if the event is pull_request_target not pull_request, because we've changed the event we dispatch on.

(I missed this in the prior two PRs. 😞 )