### PR TITLE
visual fix: reduce width and replace tabs

### DIFF
--- a/src/test-table.md
+++ b/src/test-table.md
@@ -146,9 +146,8 @@ it's acceptable to have a single branching pathway for success versus failure ca
 with a table field like `shouldErr` to specify error expectations.
 
 <table>
-<thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
-<tr><td>
+<tr><td><strong>Bad</strong></td><td>
 
 ```go
 func TestComplicatedTable(t *testing.T) {
@@ -197,7 +196,8 @@ func TestComplicatedTable(t *testing.T) {
 }
 ```
 
-</td><td>
+</td></tr>
+<tr><td><strong>Good</strong></td><td>
 
 ```go
 func TestShouldCallX(t *testing.T) {
@@ -226,6 +226,7 @@ func TestShouldCallYAndFail(t *testing.T) {
   assert.EqualError(t, err, "Y failed")
 }
 ```
+
 </td></tr>
 </tbody></table>
 

--- a/src/test-table.md
+++ b/src/test-table.md
@@ -146,8 +146,9 @@ it's acceptable to have a single branching pathway for success versus failure ca
 with a table field like `shouldErr` to specify error expectations.
 
 <table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
-<tr><td><strong>Bad</strong></td><td>
+<tr><td>
 
 ```go
 func TestComplicatedTable(t *testing.T) {
@@ -196,8 +197,7 @@ func TestComplicatedTable(t *testing.T) {
 }
 ```
 
-</td></tr>
-<tr><td><strong>Good</strong></td><td>
+</td><td>
 
 ```go
 func TestShouldCallX(t *testing.T) {
@@ -226,7 +226,6 @@ func TestShouldCallYAndFail(t *testing.T) {
   assert.EqualError(t, err, "Y failed")
 }
 ```
-
 </td></tr>
 </tbody></table>
 

--- a/src/test-table.md
+++ b/src/test-table.md
@@ -152,44 +152,48 @@ with a table field like `shouldErr` to specify error expectations.
 
 ```go
 func TestComplicatedTable(t *testing.T) {
-	tests := []struct {
-		give          string
-		want          string
-		wantErr       error
-		shouldCallX   bool
-		shouldCallY   bool
-		giveXResponse string
-		giveXErr      error
-		giveYResponse string
-		giveYErr      error
-	}{
-		// ...
-	}
+  tests := []struct {
+    give          string
+    want          string
+    wantErr       error
+    shouldCallX   bool
+    shouldCallY   bool
+    giveXResponse string
+    giveXErr      error
+    giveYResponse string
+    giveYErr      error
+  }{
+    // ...
+  }
 
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			// setup mocks
-			ctrl := gomock.NewController(t)
-			xMock := xmock.NewMockX(ctrl)
-			if tt.shouldCallX {
-				xMock.EXPECT().Call().Return(tt.giveXResponse, tt.giveXErr)
-			}
-			yMock := ymock.NewMockY(ctrl)
-			if tt.shouldCallY {
-				yMock.EXPECT().Call().Return(tt.giveYResponse, tt.giveYErr)
-			}
+  for _, tt := range tests {
+    t.Run(tt.give, func(t *testing.T) {
+      // setup mocks
+      ctrl := gomock.NewController(t)
+      xMock := xmock.NewMockX(ctrl)
+      if tt.shouldCallX {
+        xMock.EXPECT().Call().Return(
+          tt.giveXResponse, tt.giveXErr,
+        )
+      }
+      yMock := ymock.NewMockY(ctrl)
+      if tt.shouldCallY {
+        yMock.EXPECT().Call().Return(
+          tt.giveYResponse, tt.giveYErr,
+        )
+      }
 
-			got, err := DoComplexThing(tt.give, xMock, yMock)
+      got, err := DoComplexThing(tt.give, xMock, yMock)
 
-			// verify results
-			if tt.wantErr != nil {
-				require.EqualError(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, want, got)
-		})
-	}
+      // verify results
+      if tt.wantErr != nil {
+        require.EqualError(t, err, tt.wantErr)
+        return
+      }
+      require.NoError(t, err)
+      assert.Equal(t, want, got)
+    })
+  }
 }
 ```
 
@@ -197,29 +201,29 @@ func TestComplicatedTable(t *testing.T) {
 
 ```go
 func TestShouldCallX(t *testing.T) {
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	xMock := xmock.NewMockX(ctrl)
-	xMock.EXPECT().Call().Return("XResponse", nil)
+  // setup mocks
+  ctrl := gomock.NewController(t)
+  xMock := xmock.NewMockX(ctrl)
+  xMock.EXPECT().Call().Return("XResponse", nil)
 
-	yMock := ymock.NewMockY(ctrl)
+  yMock := ymock.NewMockY(ctrl)
 
-	got, err := DoComplexThing("inputX", xMock, yMock)
+  got, err := DoComplexThing("inputX", xMock, yMock)
 
-	require.NoError(t, err)
-	assert.Equal(t, "want", got)
+  require.NoError(t, err)
+  assert.Equal(t, "want", got)
 }
 
 func TestShouldCallYAndFail(t *testing.T) {
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	xMock := xmock.NewMockX(ctrl)
+  // setup mocks
+  ctrl := gomock.NewController(t)
+  xMock := xmock.NewMockX(ctrl)
 
-	yMock := ymock.NewMockY(ctrl)
-	yMock.EXPECT().Call().Return("YResponse", nil)
+  yMock := ymock.NewMockY(ctrl)
+  yMock.EXPECT().Call().Return("YResponse", nil)
 
-	_, err := DoComplexThing("inputY", xMock, yMock)
-	assert.EqualError(t, err, "Y failed")
+  _, err := DoComplexThing("inputY", xMock, yMock)
+  assert.EqualError(t, err, "Y failed")
 }
 ```
 </td></tr>

--- a/style.md
+++ b/style.md
@@ -3738,44 +3738,48 @@ with a table field like `shouldErr` to specify error expectations.
 
 ```go
 func TestComplicatedTable(t *testing.T) {
-	tests := []struct {
-		give          string
-		want          string
-		wantErr       error
-		shouldCallX   bool
-		shouldCallY   bool
-		giveXResponse string
-		giveXErr      error
-		giveYResponse string
-		giveYErr      error
-	}{
-		// ...
-	}
+  tests := []struct {
+    give          string
+    want          string
+    wantErr       error
+    shouldCallX   bool
+    shouldCallY   bool
+    giveXResponse string
+    giveXErr      error
+    giveYResponse string
+    giveYErr      error
+  }{
+    // ...
+  }
 
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			// setup mocks
-			ctrl := gomock.NewController(t)
-			xMock := xmock.NewMockX(ctrl)
-			if tt.shouldCallX {
-				xMock.EXPECT().Call().Return(tt.giveXResponse, tt.giveXErr)
-			}
-			yMock := ymock.NewMockY(ctrl)
-			if tt.shouldCallY {
-				yMock.EXPECT().Call().Return(tt.giveYResponse, tt.giveYErr)
-			}
+  for _, tt := range tests {
+    t.Run(tt.give, func(t *testing.T) {
+      // setup mocks
+      ctrl := gomock.NewController(t)
+      xMock := xmock.NewMockX(ctrl)
+      if tt.shouldCallX {
+        xMock.EXPECT().Call().Return(
+          tt.giveXResponse, tt.giveXErr,
+        )
+      }
+      yMock := ymock.NewMockY(ctrl)
+      if tt.shouldCallY {
+        yMock.EXPECT().Call().Return(
+          tt.giveYResponse, tt.giveYErr,
+        )
+      }
 
-			got, err := DoComplexThing(tt.give, xMock, yMock)
+      got, err := DoComplexThing(tt.give, xMock, yMock)
 
-			// verify results
-			if tt.wantErr != nil {
-				require.EqualError(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, want, got)
-		})
-	}
+      // verify results
+      if tt.wantErr != nil {
+        require.EqualError(t, err, tt.wantErr)
+        return
+      }
+      require.NoError(t, err)
+      assert.Equal(t, want, got)
+    })
+  }
 }
 ```
 
@@ -3783,29 +3787,29 @@ func TestComplicatedTable(t *testing.T) {
 
 ```go
 func TestShouldCallX(t *testing.T) {
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	xMock := xmock.NewMockX(ctrl)
-	xMock.EXPECT().Call().Return("XResponse", nil)
+  // setup mocks
+  ctrl := gomock.NewController(t)
+  xMock := xmock.NewMockX(ctrl)
+  xMock.EXPECT().Call().Return("XResponse", nil)
 
-	yMock := ymock.NewMockY(ctrl)
+  yMock := ymock.NewMockY(ctrl)
 
-	got, err := DoComplexThing("inputX", xMock, yMock)
+  got, err := DoComplexThing("inputX", xMock, yMock)
 
-	require.NoError(t, err)
-	assert.Equal(t, "want", got)
+  require.NoError(t, err)
+  assert.Equal(t, "want", got)
 }
 
 func TestShouldCallYAndFail(t *testing.T) {
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	xMock := xmock.NewMockX(ctrl)
+  // setup mocks
+  ctrl := gomock.NewController(t)
+  xMock := xmock.NewMockX(ctrl)
 
-	yMock := ymock.NewMockY(ctrl)
-	yMock.EXPECT().Call().Return("YResponse", nil)
+  yMock := ymock.NewMockY(ctrl)
+  yMock.EXPECT().Call().Return("YResponse", nil)
 
-	_, err := DoComplexThing("inputY", xMock, yMock)
-	assert.EqualError(t, err, "Y failed")
+  _, err := DoComplexThing("inputY", xMock, yMock)
+  assert.EqualError(t, err, "Y failed")
 }
 ```
 </td></tr>

--- a/style.md
+++ b/style.md
@@ -3732,9 +3732,8 @@ it's acceptable to have a single branching pathway for success versus failure ca
 with a table field like `shouldErr` to specify error expectations.
 
 <table>
-<thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
-<tr><td>
+<tr><td><strong>Bad</strong></td><td>
 
 ```go
 func TestComplicatedTable(t *testing.T) {
@@ -3783,7 +3782,8 @@ func TestComplicatedTable(t *testing.T) {
 }
 ```
 
-</td><td>
+</td></tr>
+<tr><td><strong>Good</strong></td><td>
 
 ```go
 func TestShouldCallX(t *testing.T) {
@@ -3812,6 +3812,7 @@ func TestShouldCallYAndFail(t *testing.T) {
   assert.EqualError(t, err, "Y failed")
 }
 ```
+
 </td></tr>
 </tbody></table>
 

--- a/style.md
+++ b/style.md
@@ -3732,8 +3732,9 @@ it's acceptable to have a single branching pathway for success versus failure ca
 with a table field like `shouldErr` to specify error expectations.
 
 <table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
-<tr><td><strong>Bad</strong></td><td>
+<tr><td>
 
 ```go
 func TestComplicatedTable(t *testing.T) {
@@ -3782,8 +3783,7 @@ func TestComplicatedTable(t *testing.T) {
 }
 ```
 
-</td></tr>
-<tr><td><strong>Good</strong></td><td>
+</td><td>
 
 ```go
 func TestShouldCallX(t *testing.T) {
@@ -3812,7 +3812,6 @@ func TestShouldCallYAndFail(t *testing.T) {
   assert.EqualError(t, err, "Y failed")
 }
 ```
-
 </td></tr>
 </tbody></table>
 


### PR DESCRIPTION
The tables added in #174 are a bit wide and hard to fit on smaller screens.

By changing the `\t` to `  `, and splitting a line, we can reduce this width.