### PR TITLE
Fix header for string-byte-slice

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -31,7 +31,7 @@
     - [No goroutines in `init()`](goroutine-init.md)
 - [Performance](performance.md)
   - [Prefer strconv over fmt](strconv.md)
-  - [Avoid string-to-byte conversion](string-byte-slice.md)
+  - [Avoid repeated string-to-byte conversions](string-byte-slice.md)
   - [Prefer Specifying Container Capacity](container-capacity.md)
 - Style
   - [Avoid overly long lines](line-length.md)

--- a/src/string-byte-slice.md
+++ b/src/string-byte-slice.md
@@ -1,4 +1,4 @@
-# Avoid string-to-byte conversion
+# Avoid string-to-byte conversion repeatedly
 
 Do not create byte slices from a fixed string repeatedly. Instead, perform the
 conversion once and capture the result.

--- a/src/string-byte-slice.md
+++ b/src/string-byte-slice.md
@@ -1,4 +1,4 @@
-# Avoid string-to-byte conversion repeatedly
+# Avoid repeated string-to-byte conversions
 
 Do not create byte slices from a fixed string repeatedly. Instead, perform the
 conversion once and capture the result.

--- a/style.md
+++ b/style.md
@@ -38,7 +38,7 @@
     - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
-  - [Avoid string-to-byte conversion repeatedly](#avoid-string-to-byte-conversion-repeatedly)
+  - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion-repeatedly)
   - [Prefer Specifying Container Capacity](#prefer-specifying-container-capacity)
 - [Style](#style)
   - [Avoid overly long lines](#avoid-overly-long-lines)

--- a/style.md
+++ b/style.md
@@ -38,7 +38,7 @@
     - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
-  - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion-repeatedly)
+  - [Avoid string-to-byte conversion repeatedly](#avoid-string-to-byte-conversion-repeatedly)
   - [Prefer Specifying Container Capacity](#prefer-specifying-container-capacity)
 - [Style](#style)
   - [Avoid overly long lines](#avoid-overly-long-lines)

--- a/style.md
+++ b/style.md
@@ -38,7 +38,7 @@
     - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
-  - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion)
+  - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion-repeatedly)
   - [Prefer Specifying Container Capacity](#prefer-specifying-container-capacity)
 - [Style](#style)
   - [Avoid overly long lines](#avoid-overly-long-lines)
@@ -2192,7 +2192,7 @@ BenchmarkStrconv-4    64.2 ns/op    1 allocs/op
 </td></tr>
 </tbody></table>
 
-### Avoid string-to-byte conversion
+### Avoid string-to-byte conversion repeatedly
 
 Do not create byte slices from a fixed string repeatedly. Instead, perform the
 conversion once and capture the result.

--- a/style.md
+++ b/style.md
@@ -38,7 +38,7 @@
     - [No goroutines in `init()`](#no-goroutines-in-init)
 - [Performance](#performance)
   - [Prefer strconv over fmt](#prefer-strconv-over-fmt)
-  - [Avoid string-to-byte conversion](#avoid-string-to-byte-conversion-repeatedly)
+  - [Avoid repeated string-to-byte conversions](#avoid-repeated-string-to-byte-conversions)
   - [Prefer Specifying Container Capacity](#prefer-specifying-container-capacity)
 - [Style](#style)
   - [Avoid overly long lines](#avoid-overly-long-lines)
@@ -2192,7 +2192,7 @@ BenchmarkStrconv-4    64.2 ns/op    1 allocs/op
 </td></tr>
 </tbody></table>
 
-### Avoid string-to-byte conversion repeatedly
+### Avoid repeated string-to-byte conversions
 
 Do not create byte slices from a fixed string repeatedly. Instead, perform the
 conversion once and capture the result.


### PR DESCRIPTION
Currently "Avoid string-to-byte conversion" sounds like we should avoid it at all, but this paragraph means else 