### PR TITLE
Update BAD Example in `import-alias.md`

### DIFF
--- a/src/import-alias.md
+++ b/src/import-alias.md
@@ -25,7 +25,7 @@ import (
   "fmt"
   "os"
 
-
+  runtimetrace "runtime/trace"
   nettrace "golang.net/x/trace"
 )
 ```

--- a/src/import-alias.md
+++ b/src/import-alias.md
@@ -24,8 +24,8 @@ direct conflict between imports.
 import (
   "fmt"
   "os"
-
   runtimetrace "runtime/trace"
+
   nettrace "golang.net/x/trace"
 )
 ```

--- a/style.md
+++ b/style.md
@@ -2649,7 +2649,7 @@ import (
   "fmt"
   "os"
 
-
+  runtimetrace "runtime/trace"
   nettrace "golang.net/x/trace"
 )
 ```

--- a/style.md
+++ b/style.md
@@ -2648,8 +2648,8 @@ direct conflict between imports.
 import (
   "fmt"
   "os"
-
   runtimetrace "runtime/trace"
+
   nettrace "golang.net/x/trace"
 )
 ```


### PR DESCRIPTION
This update refines the BAD example in `import-alias.md` to better illustrate improper usage of import aliases, making it easier for readers to understand and learn from the mistake.