### PR TITLE
MongoDB-ify this Style Guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at oss-conduct@uber.com. All
+reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,17 @@
-# Contributor Covenant Code of Conduct
+## Code of Conduct
 
-## Our Pledge
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
 
-## Our Standards
+Please also take a moment to review [MongoDB's core values][mdb-core-values].
+
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
@@ -23,15 +25,15 @@ include:
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
- advances
+advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+  address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting
 
-## Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -43,34 +45,36 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
+### Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
 
-## Enforcement
+### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
+reported by contacting the project team, or by
+[contacting GitHub][github-report-abuse]. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-## Attribution
+### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version [1.4][version].
 
-[homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[github-report-abuse]: https://github.com/contact/report-abuse
+[homepage]: https://www.contributor-covenant.org/
+[mdb-core-values]: https://www.mongodb.com/company/
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+<!--
+
 ## Translations
 
 We are aware of the following translations of this guide by the Go community.
@@ -26,3 +28,5 @@ We are aware of the following translations of this guide by the Go community.
 - **Tiếng việt** (Vietnamese): [nc-minh/uber-go-guide-vi](https://github.com/nc-minh/uber-go-guide-vi)
 
 If you have a translation, feel free to submit a PR adding it to the list.
+
+-->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This repository holds the [Uber Go Style Guide](style.md), which documents
-patterns and conventions used in Go code at Uber.
+This repository holds the [MongoDB Go Style Guide](style.md), which documents
+patterns and conventions used in Go code at MongoDB.
 
 ## Style Guide
 
-See [Uber Go Style Guide](style.md) for the style guide.
+See [MongoDB Go Style Guide](style.md) for the style guide.
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+## MongoDB-Specific Changes
+
+At MongoDB, we aim to keep this guide as close to the upstream guide maintained by Uber as
+possible. However, there will inevitable by some points of divergence over time as we develop our
+own coding standards.
+
+When you make a change specific to this MongoDB fork, always update the
+[`CHANGELOG-MongoDB.md`](./CHANGELOG-MongoDB.md) file with a summary of what you changed. This makes
+it easier to reconcile differences between the Uber and MongoDB versions of this style guide.
+
 <!--
 
 ## Translations

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](intro.md)
 - Guidelines

--- a/src/intro.md
+++ b/src/intro.md
@@ -35,3 +35,10 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>
+
+## MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](./CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes wherever we have made changes from the Uber version.

--- a/style.md
+++ b/style.md
@@ -5,7 +5,7 @@
 
 <!-- markdownlint-disable MD033 -->
 
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](#introduction)
 - [Guidelines](#guidelines)
@@ -106,6 +106,13 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
+
+### MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](src/CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes wherever we have made changes from the Uber version.
 
 ## Guidelines
 


### PR DESCRIPTION
This commit replaces some references to "Uber" with "MongoDB". It also adds a note to the intro explaining that this Style Guide is a fork of Uber's.