### PR TITLE
Fix reference to variable scoping inside parallel t.Run executions

### DIFF
--- a/style.md
+++ b/style.md
@@ -3898,32 +3898,7 @@ for multiple inputs/outputs to a system.
 
 #### Parallel Tests
 
-Parallel tests, like some specialized loops (for example, those that spawn
-goroutines or capture references as part of the loop body),
-must take care to explicitly assign loop variables within the loop's scope to
-ensure that they hold the expected values.
-
-```go
-tests := []struct{
-  give string
-  // ...
-}{
-  // ...
-}
-
-for _, tt := range tests {
-  tt := tt // for t.Parallel
-  t.Run(tt.give, func(t *testing.T) {
-    t.Parallel()
-    // ...
-  })
-}
-```
-
-In the example above, we must declare a `tt` variable scoped to the loop
-iteration because of the use of `t.Parallel()` below.
-If we do not do that, most or all tests will receive an unexpected value for
-`tt`, or a value that changes as they're running.
+Run `t.Parallel()` to improve the performance of your test cases.
 
 <!-- TODO: Explain how to use _test packages. -->
 


### PR DESCRIPTION
Since Go 1.22 that's not needed anymore, see https://tip.golang.org/doc/go1.22#language