### PR TITLE
docs: update Russian translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We are aware of the following translations of this guide by the Go community.
 - **Tradução em português** (Portuguese): [lucassscaravelli/uber-go-guide-pt](https://github.com/lucassscaravelli/uber-go-guide-pt)
 - **Tradução em português** (Portuguese BR): [alcir-junior-caju/uber-go-style-guide-pt-br](https://github.com/alcir-junior-caju/uber-go-style-guide-pt-br)
 - **Tłumaczenie polskie** (Polish): [DamianSkrzypczak/uber-go-guide-pl](https://github.com/DamianSkrzypczak/uber-go-guide-pl)
-- **Русский перевод** (Russian): [sau00/uber-go-guide-ru](https://github.com/sau00/uber-go-guide-ru)
+- **Русский перевод** (Russian): [alekarah/uber-go-guide-ru](https://github.com/alekarah/uber-go-guide-ru)
 - **Français** (French): [rm3l/uber-go-style-guide-fr](https://github.com/rm3l/uber-go-style-guide-fr)
 - **Türkçe** (Turkish): [ksckaan1/uber-go-style-guide-tr](https://github.com/ksckaan1/uber-go-style-guide-tr)
 - **Український переклад** (Ukrainian): [vorobeyme/uber-go-style-guide-uk](https://github.com/vorobeyme/uber-go-style-guide-uk)


### PR DESCRIPTION
## Summary
Update the Russian translation link to point to an actively maintained version.

## Changes
Replace `sau00/uber-go-guide-ru` (last updated November 2020) with `alekarah/uber-go-guide-ru` in the translations list.

## Details
The new translation:
- ✅ Based on the latest version (commit e2c8a0ed)
- ✅ All 58 files fully translated
- ✅ Includes updates from the past 5+ years (84 commits):
  - Goroutine lifecycle management (2022)
  - Error handling with %w, errors.Is/As (2023)
  - Updated testing recommendations (2023)  
  - Migration from golint to revive
  - Examples for Go 1.22+
