### PR TITLE
ci: disable style.md write-back for PRs created from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ '*' ]
 
 jobs:
@@ -19,14 +19,6 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-      with:
-        # Check out the pull request repository and branch.
-        # If the PR is made from a fork, this will check out the fork.
-        # This is necessary for git-auto-commit-action to update PRs made by forks.
-        # See 
-        # https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.head_ref }}
 
     - name: Check or update style.md
       uses: abhinav/stitchmd-action@v1
@@ -36,13 +28,13 @@ jobs:
         # without a local checkout.
         #
         # Otherwise, run in 'check' mode to fail CI if style.md is out-of-date.
-        mode: ${{ github.event_name == 'pull_request_target' && 'write' || 'check' }}
+        mode: ${{ github.event_name == 'pull_request' && 'write' || 'check' }}
         summary: src/SUMMARY.md
         preface: src/preface.txt
         output: style.md
 
     - uses: stefanzweifel/git-auto-commit-action@v5
-      if: ${{ github.event_name == 'pull_request_target' }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         file_pattern: style.md
         commit_message: 'Auto-update style.md'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,18 @@ and get agreement on the general direction of the change.
 - Use tables for side-by-side code samples.
 - Link to other sections with their file names (`[..](foo.md)`).
 
+## Updating style.md
+
+`style.md` is generated from the contents of `src/` using [stitchmd](https://github.com/abhinav/stitchmd).
+If CI fails because `style.md` is out of date, regenerate it by running:
+
+```bash
+make
+```
+
+This will install `stitchmd` if needed and update `style.md`.
+Commit the result and push it to your branch.
+
 ## Writing style
 
 ### Line breaks


### PR DESCRIPTION
Recently there have been different pull requests trying to steal github
secrets using a `pwn` request, and even though the current CI workflow is
safe as it doesn't execute code, but only reads changes made to markdown
files to auto-update the style.md file, using the `pull_request_target`
action is dangerous ([ref](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)).

For this reason, this commit disables the
auto-commit write-back of style.md for PRs generated from forks, and
updates the `CONTRIBUTING.md` file with instructions on how to regenerate the
file locally.