### PR TITLE
chore: migrate .golangci.yml to golangci-lint v2 config format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@
 
 version: "2"
 run:
+  timeout: 5m
   modules-download-mode: readonly
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,26 @@
 # Refer to golangci-lint's example config file for more options and information:
 # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 linters:
-  enable:
-    - errcheck
-    - goimports
-    - golint
-    - govet
-    - staticcheck
-
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,22 +5,13 @@ version: "2"
 run:
   modules-download-mode: readonly
 linters:
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
 formatters:
   enable:
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0


### PR DESCRIPTION
## Summary

Migrates `.golangci.yml` to the golangci-lint v2 configuration schema so contributors using current golangci-lint versions can run linting without first having to run `golangci-lint migrate` locally.

Closes #268.

## Changes

- Added `version: "2"`.
- Moved `goimports` from `linters.enable` to `formatters.enable` (formatters now live in their own section in v2).
- Removed `golint`, which has been deprecated and removed in newer golangci-lint versions.
- Removed `issues.exclude-use-default: false`, since not applying default exclusion presets is the v2 default.
- Preserved `run.timeout`, `run.modules-download-mode`, the remaining linters (`errcheck`, `govet`, `staticcheck`), and `issues.max-issues-per-linter` / `max-same-issues`.
